### PR TITLE
Adda downloadrst uri + templates to download very clean rst

### DIFF
--- a/django_project/changes/templates/entry/includes/entry_detail_rst.html
+++ b/django_project/changes/templates/entry/includes/entry_detail_rst.html
@@ -1,0 +1,25 @@
+{% load custom_markup %}
+{% load thumbnail %}
+{% load embed_video_tags %}
+
+<h3>Feature: {{ entry.title }}</h3>
+
+{{ entry.description|base_markdown }}
+
+{% if entry.image_file %}
+    <img id="{{ entry.image_file.url }}" class="img-responsive img-rounded pull-right"
+         src="{{ entry.image_file|thumbnail_url:'large-entry' }}"
+         alt=""/>{# see core/settings/contrib.py for large-entry #}
+{% endif %}
+
+{% if entry.video %}
+    <div class="col-lg-8 col-md-offset-1">
+        {% video entry.video 'small' %}
+    </div>
+{% endif %}
+
+<p>
+    {{ entry.funder_info_html|base_markdown }}
+    {{ entry.developer_info_html|base_markdown }}
+</p>
+

--- a/django_project/changes/templates/version/detail-content-rst.html
+++ b/django_project/changes/templates/version/detail-content-rst.html
@@ -1,0 +1,34 @@
+{% load custom_markup %}
+{% load thumbnail %}
+
+{% if version.project.image_file %}
+    <img src="{{ version.project.image_file.url }}"/>
+{% endif %}
+
+<h1>
+    Changelog for {{ version.project }} {{ version.name }}
+</h1>
+
+{% if version.image_file %}
+    <img class="img-responsive img-rounded center-block"
+         src="{{ version.image_file.url }}"/>
+{% endif %}
+
+{% if version.description %}
+        {{ version.description|base_markdown }}
+{% endif %}
+
+{% for row in version.categories %}
+    {% if row.entries %}
+        <h2 class="text-muted">
+            {{ row.category.name }}
+        </h2>
+        {% for entry in row.entries %}
+            {% if entry.approved %}
+                {% include "entry/includes/entry_detail_rst.html" %}
+            {% endif %}
+        {% endfor %}
+    {% endif %}
+{% endfor %}{# row loop #}
+
+{% include "version/includes/version-sponsors-rst.html" %}

--- a/django_project/changes/templates/version/includes/version-sponsors-rst.html
+++ b/django_project/changes/templates/version/includes/version-sponsors-rst.html
@@ -1,0 +1,40 @@
+{% load thumbnail %}
+{% load custom_markup %}
+
+{% if version.sponsors %}
+    <h2 class="text-muted" id="sponsors-heading">
+        Sponsors for {{ version.project.name }} version {{ version.name }}
+    </h2>
+
+    {% for sponsorship_level, allsponsors in sponsors.items %}
+
+        <h3 class="text-muted">
+            <img src="{% thumbnail sponsorship_level.logo 50x50 %}"/> {{ sponsorship_level }}
+        </h3>
+
+        <table border="1">
+            <tbody>
+            {% for s in allsponsors|columns:2 %}
+                <tr>
+                    {% for sponsor in s %}
+                        <td>
+                            {% if sponsor.logo %}
+                                <a href="{{ sponsor.sponsor_url }}">
+                                    <img src="{% thumbnail sponsor.logo 150x50 %}"
+                                         alt="{{ sponsor }}" />
+                                </a>
+                            {% endif %}
+                            <p>{{ sponsor }}</p>
+                        </td>
+                    {% endfor %}
+                    {% if s|length < 2 %}
+                        <td>&nbsp;</td>
+                    {% endif %}
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+
+    {% endfor %}
+
+{% endif %}

--- a/django_project/changes/urls.py
+++ b/django_project/changes/urls.py
@@ -32,6 +32,7 @@ from views import (
     PendingVersionListView,
     ApproveVersionView,
     VersionDownload,
+    VersionDownloadRST,
     VersionDownloadGnu,
     VersionSponsorDownload,
     # Entry
@@ -149,6 +150,9 @@ urlpatterns = patterns(
     url(regex='^(?P<project_slug>[\w-]+)/version/(?P<slug>[\w.-]+)/download/$',
         view=VersionDownload.as_view(),
         name='version-download'),
+    url(regex='^(?P<project_slug>[\w-]+)/version/(?P<slug>[\w.-]+)/downloadrst/$',
+        view=VersionDownloadRST.as_view(),
+        name='version-download-rst'),
     url(regex='^(?P<project_slug>[\w-]+)/version/(?P<slug>[\w.-]+)/gnu/$',
         view=VersionDownloadGnu.as_view(),
         name='version-download-gnu'),

--- a/django_project/changes/views/version.py
+++ b/django_project/changes/views/version.py
@@ -741,6 +741,11 @@ class VersionDownload(CustomStaffuserRequiredMixin, VersionMixin, DetailView):
         return temp_path
 
 
+class VersionDownloadRST(VersionDownload):
+    """View to allow staff users to download Version page in RST format."""
+    template_name = 'version/detail-content-rst.html'
+
+
 class VersionDownloadGnu(VersionMixin, DetailView):
     """A tabular list style view for a Version."""
     context_object_name = 'version'


### PR DESCRIPTION
As current rst download is so full of html, the pandoc html->rst conversion results
in very messy rst.

As that rst is probably needed in other parst of the application, I decided to create
some lean rst templates.

To create a Visual Changelog in qgis.org website costed me half a day of editing by hand :-)