### PR TITLE
add button for past sponsor rss and add test

### DIFF
--- a/django_project/changes/templates/sponsor/list.html
+++ b/django_project/changes/templates/sponsor/list.html
@@ -67,6 +67,11 @@
                        data-title="JSON Feed for Sponsors">
                         <i class="fa fa-rss-square"></i>
                     </a>
+                    <a class="btn btn-default btn-mini tooltip-toggle rss-icon"
+                       href='{% url "past-sponsor-rss-feed" project_slug %}'
+                       data-title="RSS Feed for Past Sponsors">
+                        <i class="fa fa-rss-square" style="font-weight: bold"></i>
+                    </a>
                 </div>
         </h1>
     </div>

--- a/django_project/changes/tests/test_rss_view.py
+++ b/django_project/changes/tests/test_rss_view.py
@@ -1,0 +1,95 @@
+# coding=utf-8
+import datetime
+from django.core.urlresolvers import reverse
+from django.test import TestCase, override_settings
+from django.test.client import Client
+from base.tests.model_factories import ProjectF
+from changes.tests.model_factories import (
+    SponsorshipLevelF,
+    SponsorF,
+    SponsorshipPeriodF)
+from core.model_factories import UserF
+import logging
+
+
+class PastSponsorRSSFeed(TestCase):
+    """RSS feed for past sponsor test."""
+
+    @override_settings(VALID_DOMAIN=['testserver', ])
+    def setUp(self):
+        """
+        Setup before each test
+
+        We force the locale to en otherwise it will use
+        the locale of the host running the tests and we
+        will get unpredictable results / 404s
+        """
+
+        self.client = Client()
+        self.client.post(
+            '/set_language/', data={'language': 'en'})
+        logging.disable(logging.CRITICAL)
+        self.user = UserF.create(**{
+            'username': 'anita',
+            'password': 'password',
+            'is_staff': True
+        })
+        self.user.set_password('password')
+        self.user.save()
+        self.project = ProjectF.create(
+            name='testproject')
+        self.sponsor = SponsorF.create(
+            project=self.project,
+            name='Current Sponsor')
+        self.sponsorship_level = SponsorshipLevelF.create(
+            project=self.project,
+            name='Gold')
+        self.sponsorship_period = SponsorshipPeriodF.create(
+            sponsor=self.sponsor,
+            sponsorship_level=self.sponsorship_level,
+            project=self.project,
+            approved=True,
+            end_date=datetime.date(2019, 1, 1),
+        )
+        self.past_sponsor = SponsorF.create(
+            project=self.project,
+            name='Past Sponsor')
+        self.past_sponsorship_period = SponsorshipPeriodF.create(
+            sponsor=self.past_sponsor,
+            sponsorship_level=self.sponsorship_level,
+            project=self.project,
+            approved=True,
+        )
+
+    @override_settings(VALID_DOMAIN=['testserver', ])
+    def tearDown(self):
+        """
+        Teardown after each test.
+
+        :return:
+        """
+        self.project.delete()
+        self.sponsor.delete()
+        self.sponsorship_level.delete()
+        self.sponsorship_period.delete()
+        self.past_sponsor.delete()
+        self.past_sponsorship_period.delete()
+        self.user.delete()
+
+    @override_settings(VALID_DOMAIN=['testserver', ])
+    def test_past_sponsor_rss_feed_view(self):
+        response = self.client.get(reverse('past-sponsor-rss-feed', kwargs={
+            'project_slug': self.project.slug
+        }))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual('Past Sponsor' in response.content, True)
+        self.assertEqual('New Sponsor' in response.content, False)
+
+    @override_settings(VALID_DOMAIN=['testserver', ])
+    def test_current_sponsor_rss_feed_view(self):
+        response = self.client.get(reverse('sponsor-rss-feed', kwargs={
+            'project_slug': self.project.slug
+        }))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual('Past Sponsor' in response.content, False)
+        self.assertEqual('Current Sponsor' in response.content, True)


### PR DESCRIPTION
follow up for #931 and fix #936 

- [x] Added past sponsor rss button
- [x] Added test

The past sponsor button:
![screenshot from 2018-05-30 11-37-20](https://user-images.githubusercontent.com/26101337/40699330-dec06136-63fd-11e8-9ebd-d9cfefc32208.png)

This button is slightly different than the other rss buttons:
![peek 2018-05-30 11-38](https://user-images.githubusercontent.com/26101337/40699365-0a6eea14-63fe-11e8-836d-d2081ba02315.gif)
