### PR TITLE
update template download rst with the new one

### DIFF
--- a/django_project/changes/urls.py
+++ b/django_project/changes/urls.py
@@ -32,7 +32,6 @@ from views import (
     PendingVersionListView,
     ApproveVersionView,
     VersionDownload,
-    VersionDownloadRST,
     VersionDownloadGnu,
     VersionSponsorDownload,
     # Entry
@@ -150,9 +149,6 @@ urlpatterns = patterns(
     url(regex='^(?P<project_slug>[\w-]+)/version/(?P<slug>[\w.-]+)/download/$',
         view=VersionDownload.as_view(),
         name='version-download'),
-    url(regex='^(?P<project_slug>[\w-]+)/version/(?P<slug>[\w.-]+)/downloadrst/$',
-        view=VersionDownloadRST.as_view(),
-        name='version-download-rst'),
     url(regex='^(?P<project_slug>[\w-]+)/version/(?P<slug>[\w.-]+)/gnu/$',
         view=VersionDownloadGnu.as_view(),
         name='version-download-gnu'),

--- a/django_project/changes/views/version.py
+++ b/django_project/changes/views/version.py
@@ -637,7 +637,7 @@ class ApproveVersionView(LoginRequiredMixin, VersionMixin, RedirectView):
 
 class VersionDownload(CustomStaffuserRequiredMixin, VersionMixin, DetailView):
     """View to allow staff users to download Version page in RST format."""
-    template_name = 'version/detail-content.html'
+    template_name = 'version/detail-content-rst.html'
 
     def get_context_data(self, **kwargs):
         """Get the context data which is passed to a template.
@@ -739,11 +739,6 @@ class VersionDownload(CustomStaffuserRequiredMixin, VersionMixin, DetailView):
                 document)
 
         return temp_path
-
-
-class VersionDownloadRST(VersionDownload):
-    """View to allow staff users to download Version page in RST format."""
-    template_name = 'version/detail-content-rst.html'
 
 
 class VersionDownloadGnu(VersionMixin, DetailView):


### PR DESCRIPTION
fix #935 

This PR:
- [x] update the previous download RST template logic view to use the new templates from #934 . 