### PR TITLE
fix slug duplicates

### DIFF
--- a/django_project/certification/tests/views/test_course_view.py
+++ b/django_project/certification/tests/views/test_course_view.py
@@ -66,6 +66,28 @@ class TestCourseView(TestCase):
         self.assertEqual(response.status_code, 200)
 
     @override_settings(VALID_DOMAIN=['testserver', ])
+    def test_detail_with_duplicates(self):
+        self.client.login(username='anita', password='password')
+        course2 = CourseF.create(
+            certifying_organisation=self.certifying_organisation
+        )
+        course2.slug = self.course.slug
+        course2.save()
+
+        response = self.client.get(reverse('course-detail', kwargs={
+            'project_slug': self.project.slug,
+            'organisation_slug': self.certifying_organisation.slug,
+            'slug': course2.slug
+        }))
+        self.assertEqual(response.status_code, 302)
+
+        expected_url = reverse('certifyingorganisation-detail', kwargs={
+            'project_slug': self.project.slug,
+            'slug': self.certifying_organisation.slug,
+        })
+        self.assertRedirects(response, expected_url)
+
+    @override_settings(VALID_DOMAIN=['testserver', ])
     def test_detail_view_object_does_not_exist(self):
         client = Client()
         response = client.get(reverse('course-detail', kwargs={
@@ -80,3 +102,63 @@ class TestCourseView(TestCase):
             'slug': 'random'
         }))
         self.assertEqual(response.status_code, 404)
+
+    @override_settings(VALID_DOMAIN=['testserver', ])
+    def test_update_view(self):
+        self.client.login(username='anita', password='password')
+        post_data = {
+            'name': 'new name',
+            'language': 'Japanese',
+        }
+        response = self.client.post(
+            reverse('course-update', kwargs={
+                'project_slug': self.project.slug,
+                'organisation_slug': self.certifying_organisation.slug,
+                'slug': self.course.slug
+            }), post_data)
+        self.assertEqual(response.status_code, 200)
+
+    @override_settings(VALID_DOMAIN=['testserver', ])
+    def test_update_with_duplicates(self):
+        self.client.login(username='anita', password='password')
+        course2 = CourseF.create(
+            certifying_organisation=self.certifying_organisation
+        )
+        course2.slug = self.course.slug
+        course2.save()
+        post_data = {
+            'name': 'new course name',
+            'language': 'Indonesian',
+        }
+        response = self.client.get(reverse('course-update', kwargs={
+            'project_slug': self.project.slug,
+            'organisation_slug': self.certifying_organisation.slug,
+            'slug': course2.slug
+        }), post_data)
+        self.assertEqual(response.status_code, 302)
+
+        expected_url = reverse('certifyingorganisation-detail', kwargs={
+            'project_slug': self.project.slug,
+            'slug': self.certifying_organisation.slug,
+        })
+        self.assertRedirects(response, expected_url)
+
+    @override_settings(VALID_DOMAIN=['testserver', ])
+    def test_delete_with_duplicates(self):
+        self.client.login(username='anita', password='password')
+        course2 = CourseF.create(
+            certifying_organisation=self.certifying_organisation
+        )
+        course2.slug = self.course.slug
+        course2.save()
+        response = self.client.get(reverse('course-delete', kwargs={
+            'project_slug': self.project.slug,
+            'organisation_slug': self.certifying_organisation.slug,
+            'slug': course2.slug
+        }))
+        self.assertEqual(response.status_code, 302)
+        expected_url = reverse('certifyingorganisation-detail', kwargs={
+            'project_slug': self.project.slug,
+            'slug': self.certifying_organisation.slug,
+        })
+        self.assertRedirects(response, expected_url)

--- a/django_project/certification/views/course.py
+++ b/django_project/certification/views/course.py
@@ -234,7 +234,7 @@ class CourseUpdateView(LoginRequiredMixin, CourseMixin, UpdateView):
                     objects = queryset.filter(
                         certifying_organisation=certifying_organisation,
                         slug=slug)
-                    latest_obj = len(objects)-1
+                    latest_obj = len(objects) - 1
                     objects[latest_obj].slug = new_slug
                     objects[latest_obj].save()
                     raise PermissionDenied
@@ -374,7 +374,7 @@ class CourseDeleteView(LoginRequiredMixin, CourseMixin, DeleteView):
                     objects = queryset.filter(
                         certifying_organisation=certifying_organisation,
                         slug=slug)
-                    latest_obj = len(objects)-1
+                    latest_obj = len(objects) - 1
                     objects[latest_obj].slug = new_slug
                     objects[latest_obj].save()
                     raise PermissionDenied
@@ -506,7 +506,7 @@ class CourseDetailView(CourseMixin, DetailView):
                     objects = queryset.filter(
                         certifying_organisation=certifying_organisation,
                         slug=slug)
-                    latest_obj = len(objects)-1
+                    latest_obj = len(objects) - 1
                     objects[latest_obj].slug = new_slug
                     objects[latest_obj].save()
                     raise PermissionDenied

--- a/django_project/certification/views/course.py
+++ b/django_project/certification/views/course.py
@@ -118,7 +118,7 @@ class CourseUpdateView(LoginRequiredMixin, CourseMixin, UpdateView):
         try:
             self.object = self.get_object()
         except PermissionDenied:
-            # Return to organisation details page when permission to delete
+            # Return to organisation details page when permission to edit
             # is denied.
             return HttpResponseRedirect(
                 reverse('certifyingorganisation-detail', kwargs={
@@ -422,7 +422,7 @@ class CourseDetailView(CourseMixin, DetailView):
         try:
             self.object = self.get_object()
         except PermissionDenied:
-            # Return to organisation details page when permission to delete
+            # Return to organisation details page when permission to view
             # is denied.
             return HttpResponseRedirect(
                 reverse('certifyingorganisation-detail', kwargs={

--- a/django_project/certification/views/course.py
+++ b/django_project/certification/views/course.py
@@ -108,8 +108,12 @@ class CourseUpdateView(LoginRequiredMixin, CourseMixin, UpdateView):
         """
 
         self.organisation_slug = self.kwargs.get('organisation_slug', None)
-        self.certifying_organisation = \
-            CertifyingOrganisation.objects.get(slug=self.organisation_slug)
+        try:
+            self.certifying_organisation = \
+                CertifyingOrganisation.objects.get(slug=self.organisation_slug)
+        except CertifyingOrganisation.DoesNotExist:
+            raise Http404(
+                'Sorry! We could not find your certifying organisation!')
 
         try:
             self.object = self.get_object()
@@ -266,8 +270,12 @@ class CourseDeleteView(LoginRequiredMixin, CourseMixin, DeleteView):
         """
 
         self.organisation_slug = self.kwargs.get('organisation_slug', None)
-        self.certifying_organisation = \
-            CertifyingOrganisation.objects.get(slug=self.organisation_slug)
+        try:
+            self.certifying_organisation = \
+                CertifyingOrganisation.objects.get(slug=self.organisation_slug)
+        except CertifyingOrganisation.DoesNotExist:
+            raise Http404(
+                'Sorry! We could not find your certifying organisation!')
 
         try:
             self.object = self.get_object()
@@ -280,8 +288,7 @@ class CourseDeleteView(LoginRequiredMixin, CourseMixin, DeleteView):
                     'slug': self.certifying_organisation.slug
                 }))
 
-        return super(
-            CourseDeleteView, self).get(request, *args, **kwargs)
+        return super(CourseDeleteView, self).get(request, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):
         """Post the organisation_slug from the URL.
@@ -302,8 +309,7 @@ class CourseDeleteView(LoginRequiredMixin, CourseMixin, DeleteView):
         self.organisation_slug = self.kwargs.get('organisation_slug', None)
         self.certifying_organisation = \
             CertifyingOrganisation.objects.get(slug=self.organisation_slug)
-        return super(
-            CourseDeleteView, self).post(request, *args, **kwargs)
+        return super(CourseDeleteView, self).post(request, *args, **kwargs)
 
     def get_success_url(self):
         """Define the redirect URL.
@@ -406,8 +412,12 @@ class CourseDetailView(CourseMixin, DetailView):
         """
 
         self.organisation_slug = self.kwargs.get('organisation_slug', None)
-        self.certifying_organisation = \
-            CertifyingOrganisation.objects.get(slug=self.organisation_slug)
+        try:
+            self.certifying_organisation = \
+                CertifyingOrganisation.objects.get(slug=self.organisation_slug)
+        except CertifyingOrganisation.DoesNotExist:
+            raise Http404(
+                'Sorry! We could not find your certifying organisation!')
 
         try:
             self.object = self.get_object()


### PR DESCRIPTION
fix #956 and fix http://sentry.kartoza.com/sentry/projecta/issues/290/

This PR fixes slug duplicates for courses:
- [x] when clicking delete/update button and the found multiple objects with the same slug, this will auto update the slug, the latest object will have its slug incremented then reload the certifying organisation detail view.
- [x] upon new creation course, it will increment the slug when same slug exists.


example for case http://sentry.kartoza.com/sentry/projecta/issues/290/
![peek 2018-06-21 10-00](https://user-images.githubusercontent.com/26101337/41695886-5584351a-753b-11e8-8cbb-586e25a58660.gif)
