### PR TITLE
add project representative field

### DIFF
--- a/django_project/base/forms.py
+++ b/django_project/base/forms.py
@@ -96,7 +96,8 @@ class ProjectForm(forms.ModelForm):
             'project_repository_url',
             'precis',
             'gitter_room',
-            'signature',
+            'project_representative',
+            'project_representative_signature',
             'changelog_managers',
             'sponsorship_managers',
             'lesson_managers',
@@ -121,7 +122,12 @@ class ProjectForm(forms.ModelForm):
                 Field('project_url', css_class="form-control"),
                 Field('project_repository_url', css_class="form-control"),
                 Field('precis', css_class="form-control"),
-                Field('signature', css_class="form-control"),
+                Field(
+                    'project_representative',
+                    css_class="chosen-select"),
+                Field(
+                    'project_representative_signature',
+                    css_class="form-control"),
                 Field('changelog_managers', css_class="form-control"),
                 Field('sponsorship_managers', css_class="form-control"),
                 Field('lesson_managers', css_class="form-control"),
@@ -142,6 +148,8 @@ class ProjectForm(forms.ModelForm):
         self.fields['certification_managers'].label_from_instance = \
             lambda obj: "%s <%s>" % (obj.get_full_name(), obj)
         self.fields['lesson_managers'].label_from_instance = \
+            lambda obj: "%s <%s>" % (obj.get_full_name(), obj)
+        self.fields['project_representative'].label_from_instance = \
             lambda obj: "%s <%s>" % (obj.get_full_name(), obj)
         # self.helper.add_input(Submit('submit', 'Submit'))
 

--- a/django_project/base/migrations/0021_auto_20180702_0420.py
+++ b/django_project/base/migrations/0021_auto_20180702_0420.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('base', '0020_auto_20180226_1401'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='project',
+            old_name='signature',
+            new_name='project_representative_signature',
+        ),
+        migrations.AddField(
+            model_name='project',
+            name='project_representative',
+            field=models.ForeignKey(related_name='project_representative', blank=True, to=settings.AUTH_USER_MODEL, help_text='Project representative. This name will be used on invoices and certificates. ', null=True),
+        ),
+    ]

--- a/django_project/base/migrations/0022_auto_20180702_0420.py
+++ b/django_project/base/migrations/0022_auto_20180702_0420.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0021_auto_20180702_0420'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='project',
+            name='project_representative_signature',
+            field=models.ImageField(help_text='This signature will be used on invoices and certificates. Most browsers support dragging the image directly on to the "Choose File" button above.', upload_to=b'images/projects/signatures', blank=True),
+        ),
+    ]

--- a/django_project/base/models/project.py
+++ b/django_project/base/models/project.py
@@ -117,9 +117,10 @@ class Project(models.Model):
         null=True,
         default='#FF0000')
 
-    signature = models.ImageField(
+    project_representative_signature = models.ImageField(
         help_text=_(
-            'Signature of the project owner. Most browsers support dragging '
+            'This signature will be used on invoices and certificates. '
+            'Most browsers support dragging '
             'the image directly on to the "Choose File" button above.'),
         upload_to=os.path.join(MEDIA_ROOT, 'images/projects/signatures'),
         blank=True
@@ -226,6 +227,16 @@ class Project(models.Model):
         default=get_default_organisation,
         null=True,
         on_delete=models.SET_DEFAULT,
+    )
+
+    project_representative = models.ForeignKey(
+        User,
+        related_name='project_representative',
+        help_text=_(
+            'Project representative. '
+            'This name will be used on invoices and certificates. '),
+        blank=True,
+        null=True # This is needed to populate existing database.
     )
 
     owner = models.ForeignKey(User)

--- a/django_project/base/models/project.py
+++ b/django_project/base/models/project.py
@@ -236,7 +236,7 @@ class Project(models.Model):
             'Project representative. '
             'This name will be used on invoices and certificates. '),
         blank=True,
-        null=True # This is needed to populate existing database.
+        null=True  # This is needed to populate existing database.
     )
 
     owner = models.ForeignKey(User)

--- a/django_project/base/static/js/custom-project-form.js
+++ b/django_project/base/static/js/custom-project-form.js
@@ -1,0 +1,3 @@
+$(document).ready(function () {
+    $('#id_project_representative').css('cssText', 'display: none !important;');
+});

--- a/django_project/base/templates/project/create.html
+++ b/django_project/base/templates/project/create.html
@@ -48,4 +48,5 @@
 </div>
 </section>
 
+<script type="text/javascript" src="/static/js/custom-project-form.js"></script>
 {% endblock %}

--- a/django_project/base/templates/project/update.html
+++ b/django_project/base/templates/project/update.html
@@ -56,4 +56,5 @@
         $(this).hide();
     });
 </script>
+<script type="text/javascript" src="/static/js/custom-project-form.js"></script>
 {% endblock %}

--- a/django_project/base/tests/model_factories.py
+++ b/django_project/base/tests/model_factories.py
@@ -14,6 +14,7 @@ class ProjectF(factory.django.DjangoModelFactory):
     name = factory.Sequence(lambda n: 'Test Project %s' % n)
     description = u'This is only for testing'
     owner = factory.SubFactory(UserF)
+    project_representative = factory.SubFactory(UserF)
     approved = True
     private = False
     gitter_room = u'test/test'

--- a/django_project/certification/tests/views/test_certificate_views.py
+++ b/django_project/certification/tests/views/test_certificate_views.py
@@ -2,7 +2,6 @@
 import logging
 from mock import patch, MagicMock
 from django.core.urlresolvers import reverse
-from django.http import Http404
 from django.test.client import RequestFactory
 from django.test import TestCase, override_settings
 from django.test.client import Client

--- a/django_project/certification/tests/views/test_certificate_views.py
+++ b/django_project/certification/tests/views/test_certificate_views.py
@@ -1,12 +1,10 @@
 # coding=utf-8
-from io import BytesIO
 from StringIO import StringIO
 import logging
 from mock import patch, MagicMock
 from PIL import Image
 from django.core.files.base import ContentFile
 from django.core.urlresolvers import reverse
-from django.core.files.images import ImageFile
 from django.test.client import RequestFactory
 from django.test import TestCase, override_settings
 from django.test.client import Client

--- a/django_project/certification/tests/views/test_certificate_views.py
+++ b/django_project/certification/tests/views/test_certificate_views.py
@@ -44,6 +44,14 @@ class TestCertificateView(TestCase):
             'username': 'anita',
             'password': 'password',
             'is_staff': True,
+        })
+        self.user.set_password('password')
+        self.user.save()
+
+        self.user2 = UserF.create(**{
+            'username': 'anita2',
+            'password': 'password',
+            'is_staff': True,
             'first_name': 'Anita',
             'last_name': 'Hapsari',
         })
@@ -52,7 +60,7 @@ class TestCertificateView(TestCase):
 
         self.project = ProjectF.create(
             owner=self.user,
-            project_representative=self.user
+            project_representative=self.user2
         )
         self.certifying_organisation = \
             CertifyingOrganisationF.create()

--- a/django_project/certification/tests/views/test_certificate_views.py
+++ b/django_project/certification/tests/views/test_certificate_views.py
@@ -1,10 +1,8 @@
 # coding=utf-8
 import tempfile
-from StringIO import StringIO
 import logging
 from mock import patch, MagicMock
 from PIL import Image
-from django.core.files.base import ContentFile
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 from django.test import TestCase, override_settings

--- a/django_project/certification/tests/views/test_certificate_views.py
+++ b/django_project/certification/tests/views/test_certificate_views.py
@@ -111,19 +111,21 @@ class TestCertificateView(TestCase):
     @patch('os.path.exists')
     @patch('os.makedirs')
     @patch('__builtin__.open', create=True)
-    @patch('reportlab.lib.utils.ImageReader')
     def test_generate_certificate_with_signature(
-            self, mock_open, mock_make_dirs, mock_exists, mock_image_reader):
+            self, mock_open, mock_make_dirs, mock_exists):
         mock_open.return_value = MagicMock()
         mock_exists.return_value = False
-        mock_image_reader.return_value = MagicMock()
 
+        # Add mock signature for test.
         image = Image.new('RGBA', size=(50, 50), color=(256, 0, 0))
         image_file = BytesIO()
         image.save(image_file, 'PNG')
         signature = ImageFile(image_file)
         self.project.project_representative_signature = signature
         self.project.save()
+
+        self.course_convener.signature = signature
+        self.course_convener.save()
 
         client = Client(HTTP_HOST='testserver')
         client.login(username='anita', password='password')
@@ -136,6 +138,8 @@ class TestCertificateView(TestCase):
         self.assertEqual(response.status_code, 200)
         self.project.project_representative_signature = None
         self.project.save()
+        self.course_convener.signature = None
+        self.course_convener.save()
 
     @override_settings(VALID_DOMAIN=['testserver', ])
     @patch('os.path.exists')

--- a/django_project/certification/views/certificate.py
+++ b/django_project/certification/views/certificate.py
@@ -267,10 +267,11 @@ def generate_pdf(
     else:
         organisation_logo = None
 
-    if project.signature:
-        project_owner_signature = ImageReader(project.signature)
+    if project.project_representative_signature:
+        project_representative_signature = \
+            ImageReader(project.project_representative_signature)
     else:
-        project_owner_signature = None
+        project_representative_signature = None
 
     if course.course_convener.signature:
         convener_signature = ImageReader(course.course_convener.signature)
@@ -335,9 +336,9 @@ def generate_pdf(
             convener_name,
             course.training_center))
 
-    if project_owner_signature is not None:
+    if project_representative_signature is not None:
         page.drawImage(
-            project_owner_signature,
+            project_representative_signature,
             (margin_left + 100),
             (margin_bottom + 70),
             width=100,
@@ -356,8 +357,8 @@ def generate_pdf(
     page.drawCentredString(
         (margin_left + 150), (margin_bottom + 60),
         '{} {}'.format(
-            project.owner.first_name.encode('utf-8'),
-            project.owner.last_name.encode('utf-8')))
+            project.project_representative.first_name.encode('utf-8'),
+            project.project_representative.last_name.encode('utf-8')))
     page.drawCentredString(
         (margin_right - 150), (margin_bottom + 60),
         '{}'.format(convener_name))
@@ -628,7 +629,8 @@ def regenerate_certificate(request, **kwargs):
     # Checking user permissions.
     if request.user.is_staff or request.user == project.owner or \
             request.user in project.certification_managers.all() or \
-            request.user in certifying_organisation.organisation_owners.all():
+            request.user in certifying_organisation.organisation_owners.all() \
+            or request.user == project.project_representative:
         pass
     else:
         raise Http404
@@ -689,7 +691,8 @@ def regenerate_all_certificate(request, **kwargs):
     # Checking user permissions.
     if request.user.is_staff or request.user == project.owner or \
             request.user in project.certification_managers.all() or \
-            request.user in certifying_organisation.organisation_owners.all():
+            request.user in certifying_organisation.organisation_owners.all() \
+            or request.user == project.project_representative:
         pass
     else:
         raise Http404

--- a/django_project/certification/views/certificate.py
+++ b/django_project/certification/views/certificate.py
@@ -354,11 +354,12 @@ def generate_pdf(
             mask='auto')
 
     page.setFont('Times-Italic', 12)
-    page.drawCentredString(
-        (margin_left + 150), (margin_bottom + 60),
-        '{} {}'.format(
-            project.project_representative.first_name.encode('utf-8'),
-            project.project_representative.last_name.encode('utf-8')))
+    if project.project_representative:
+        page.drawCentredString(
+            (margin_left + 150), (margin_bottom + 60),
+            '{} {}'.format(
+                project.project_representative.first_name.encode('utf-8'),
+                project.project_representative.last_name.encode('utf-8')))
     page.drawCentredString(
         (margin_right - 150), (margin_bottom + 60),
         '{}'.format(convener_name))


### PR DESCRIPTION
fix #959 and fix #966 

This PR:
- [x] Rename field signature to project_representative_signature (your uploaded signature in this field won't be affected)
- [x] Add project_representative field
- [x] Change help text for project representative signature
- [x] Update project form
- [x] Change project owner name in the certificate to user project representative name
- [x] Update permissions for project representative


Form:
![screenshot from 2018-07-02 09-42-31](https://user-images.githubusercontent.com/26101337/42143092-82d2d1c0-7ddd-11e8-90bb-702e22a12e47.png)
![peek 2018-07-02 09-45](https://user-images.githubusercontent.com/26101337/42143099-924494f4-7ddd-11e8-9248-c45c72a3d162.gif)

Regenerate existing certificate will change the name of project representative:
![peek 2018-07-02 09-47](https://user-images.githubusercontent.com/26101337/42143123-b93f7e52-7ddd-11e8-9185-77290d92d73f.gif)
