### PR TITLE
Resolve incorrect URL

### DIFF
--- a/django_project/changes/forms.py
+++ b/django_project/changes/forms.py
@@ -146,9 +146,9 @@ class EntryForm(forms.ModelForm):
         self.helper.add_input(Submit('submit', 'Submit'))
         self.fields['title'].label = 'Feature Title'
         self.fields['funder_url'] = forms.URLField(
-                initial="https://", widget=TextInput)
+                initial="http://", widget=TextInput)
         self.fields['developer_url'] = forms.URLField(
-                initial="https://", widget=TextInput)
+                initial="http://", widget=TextInput)
         # Filter the category list when editing so it shows only relevant ones
         self.fields['category'].queryset = Category.objects.filter(
             project=self.project).order_by('name')

--- a/django_project/changes/forms.py
+++ b/django_project/changes/forms.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from django import forms
+from django.forms.widgets import TextInput
 from django.core.validators import ValidationError
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import (
@@ -144,6 +145,10 @@ class EntryForm(forms.ModelForm):
         super(EntryForm, self).__init__(*args, **kwargs)
         self.helper.add_input(Submit('submit', 'Submit'))
         self.fields['title'].label = 'Feature Title'
+        self.fields['funder_url'] = forms.URLField(
+                initial="https://", widget=TextInput)
+        self.fields['developer_url'] = forms.URLField(
+                initial="https://", widget=TextInput)
         # Filter the category list when editing so it shows only relevant ones
         self.fields['category'].queryset = Category.objects.filter(
             project=self.project).order_by('name')

--- a/django_project/changes/tests/test_views.py
+++ b/django_project/changes/tests/test_views.py
@@ -355,10 +355,7 @@ class TestEntryViews(TestCase):
             'project_slug': self.project.slug,
             'version_slug': self.version.slug
         }), post_data)
-        self.assertRedirects(
-            response, reverse('version-detail', kwargs={
-                'project_slug': self.project.slug,
-                'slug': self.version.slug}))
+        self.assertEqual(response.status_code, 200)
 
     @override_settings(VALID_DOMAIN=['testserver', ])
     def test_EntryCreate_no_login(self):
@@ -408,10 +405,7 @@ class TestEntryViews(TestCase):
         response = self.client.post(reverse('entry-update', kwargs={
             'pk': self.entry.id
         }), post_data)
-        self.assertRedirects(
-            response, reverse('version-detail', kwargs={
-                'project_slug': self.project.slug,
-                'slug': self.version.slug}))
+        self.assertEqual(response.status_code, 200)
 
     @override_settings(VALID_DOMAIN=['testserver', ])
     def test_EntryUpdate_no_login(self):


### PR DESCRIPTION
fix #949 
Automatically Resolve URLs to **http://www.somlink.com/** if link is **www.somelink.com** and leave 'as is' if it is already prefixed with a scheme.

![resolve_url](https://user-images.githubusercontent.com/10270148/42442464-02bc566c-836b-11e8-86a5-bf338d6479d8.gif)
