### PR TITLE
add sign up button

### DIFF
--- a/django_project/certification/templates/certifying_organisation/list.html
+++ b/django_project/certification/templates/certifying_organisation/list.html
@@ -22,29 +22,39 @@
         <h1 class="text-muted">
             {% if unapproved %}Unapproved {% endif %}
             Certifying Organisations
-            {% if user.is_staff or user == the_project.owner or user in the_project.certification_managers.all %}
-                <div class="pull-right btn-group">
-                    <a class="btn btn-default btn-mini tooltip-toggle"
-                       href='{% url "certifyingorganisation-create" project_slug %}'
-                       data-title="Create New Certifying Organisation">
-                        {% show_button_icon "add" %}
-                    </a>
-                    {% if not unapproved %}
-                        <a class="btn btn-default btn-mini tooltip-toggle"
-                           href='{% url "pending-certifyingorganisation-list" project_slug %}'
-                           data-title="View Pending Certifying Organisations">
-                            <span class="glyphicon glyphicon-time"></span>
-                        </a>
-                    {% else %}
-                        <a class="btn btn-default btn-mini tooltip-toggle"
-                           href='{% url "certifyingorganisation-list" project_slug %}'
-                           data-title="View Certifying Organisations">
-                            <span class="glyphicon glyphicon-th-list"></span>
-                        </a>
-                    {% endif %}
 
+                <div class="pull-right btn-group">
+                    <a class="btn btn-primary btn-mini tooltip-toggle"
+                       href='{% url "certifyingorganisation-create" project_slug %}'
+                       data-title="Sign Up for Certification!">
+                        Sign Up
+                    </a>
+                    {% if user.is_staff or user == the_project.owner or user in the_project.certification_managers.all %}
+                        <a class="btn btn-default btn-mini tooltip-toggle"
+                           href='{% url "certifyingorganisation-create" project_slug %}'
+                           data-title="Create New Certifying Organisation">
+                            {% show_button_icon "add" %}
+                        </a>
+                        {% if not unapproved %}
+                            <a class="btn btn-default btn-mini tooltip-toggle"
+                               href='{% url "pending-certifyingorganisation-list" project_slug %}'
+                               data-title="View Pending Certifying Organisations">
+                                <span class="glyphicon glyphicon-time"></span>
+                            </a>
+                        {% else %}
+                            <a class="btn btn-default btn-mini tooltip-toggle"
+                               href='{% url "certifyingorganisation-list" project_slug %}'
+                               data-title="View Certifying Organisations">
+                                <span class="glyphicon glyphicon-th-list"></span>
+                            </a>
+                        {% endif %}
+                    {% endif %}
+                    <a class="btn btn-default btn-mini tooltip-toggle"
+                       href='{% url 'about' the_project.slug %}'
+                       data-title="About Certification">
+                        <i class="glyphicon glyphicon-info-sign"></i>
+                    </a>
                 </div>
-            {% endif %}
         </h1>
     </div>
 


### PR DESCRIPTION
fix #947 

I added the sign up button and about certification icon. These two icons are available for public.
When non logged in user click on sign up button, it will redirect them to login page then after login they'll see the create a new certifying organisation form.

Public:
![peek 2018-10-24 16-01](https://user-images.githubusercontent.com/26101337/47419580-b53cbe00-d7a6-11e8-836e-2f786a32369c.gif)

Logged in user:
![screenshot from 2018-10-24 16-02-59](https://user-images.githubusercontent.com/26101337/47419651-db625e00-d7a6-11e8-9a78-1c8c6aaf225e.png)
