### PR TITLE
Create custom json feed

### DIFF
--- a/django_project/changes/feeds/json_rss_feed.py
+++ b/django_project/changes/feeds/json_rss_feed.py
@@ -12,6 +12,7 @@ class JSONFeed(SyndicationFeed):
         data['rss']['channel'] = self.add_root_elements()
 
         if self.items:
+
             item_element = []
 
             for item in self.items:
@@ -43,7 +44,21 @@ class JSONFeed(SyndicationFeed):
             domain_url = self.feed['link']
             head, sep, tail = domain_url.partition('/en/')
             item_elements['image_url'] = head + item['image_url']
-
+        # Add sponsor_level
+        if item['sponsor_level'] is not None:
+            item_elements['sponsor_level'] = item['sponsor_level']
+        # Country
+        if item['sponsor_country'] is not None:
+            item_elements['sponsor_country'] = unicode(item['sponsor_country'])
+        # Start date
+        if item['start_date'] is not None:
+            item_elements['start_date'] = item['start_date']
+        # End date
+        if item['end_date'] is not None:
+            item_elements['end_date'] = item['end_date']
+        # Sponsor url
+        if item['sponsor_url'] is not None:
+            item_elements['sponsor_url'] = item['sponsor_url']
         return item_elements
 
     def add_root_elements(self):

--- a/django_project/changes/feeds/sponsor.py
+++ b/django_project/changes/feeds/sponsor.py
@@ -130,8 +130,16 @@ class RssSponsorFeed(Feed):
             .format(**data)
         return descriptions
 
+    #def item_extra_kwargs(self, item):
+    #    return {'image_url': item.sponsor.logo.url}
     def item_extra_kwargs(self, item):
-        return {'image_url': item.sponsor.logo.url}
+        return {
+            'image_url': item.sponsor.logo.url,
+            'sponsor_level': item.sponsorship_level.name,
+            'sponsor_country': item.sponsor.country.name,
+            'start_date': item.start_date.strftime('%Y%m%d'),  # '%d %B %Y' => "16 March 2019"
+            'end_date': item.end_date.strftime('%d %B %Y')     # '%Y%m%d'   => "20181012"
+        }
 
 
 class RssPastSponsorFeed(RssSponsorFeed):
@@ -178,7 +186,109 @@ class AtomPastSponsorFeed(RssPastSponsorFeed):
     subtitle = RssPastSponsorFeed.description
 
 
-class JSONSponsorFeed(RssSponsorFeed):
+class JSONSponsorFeed(Feed):
     """JSON Feed class for sponsor."""
 
     feed_type = JSONFeed
+
+    def get_object(self, request, *args, **kwargs):
+        """Return project object that matches the project_slug.
+
+        :param request: The incoming HTTP request object
+        :type request: HttpRequest
+
+        :param args: Positional arguments
+        :type args: tuple
+
+        :param kwargs: Keyword arguments
+        :type kwargs: dict
+
+        :returns: A project
+        :rtype: Project
+
+        :raises: Http404
+        """
+        project_slug = kwargs.get('project_slug', None)
+        self.domain_path_url = request.build_absolute_uri(reverse('home'))
+        return get_object_or_404(Project, slug=project_slug)
+
+    def title(self, obj):
+        """Return a title for the RSS.
+
+         :param obj: A project
+         :type obj: Project
+
+         :returns: Title of the RSS Feed.
+         :rtype: str
+         """
+        return 'JSON Sponsors of %s Project' % obj.name
+
+    def description(self, obj):
+        """Return a description for the RSS.
+
+         :param obj: A project
+         :type obj: Project
+
+         :returns: Description of the RSS Feed.
+         :rtype: str
+         """
+        return 'These are the latest sponsors of %s project.' % obj.name
+
+    def link(self, obj):
+        """Return the url of the latest sponsor.
+
+        :param obj: Latest sponsor of a project
+        :type obj: SponsorshipPeriod
+
+        :returns: Url of the latest sponsor.
+        :rtype: str
+        """
+        return obj.get_absolute_url()
+
+    def items(self, obj):
+        """Return latest sponsors of the project.
+        NOT
+
+        :param obj: A project
+        :type obj: Project
+
+        :returns: List of latest sponsor of a project
+        :rtype: list
+        """
+        today = datetime.datetime.now().date()
+        return SponsorshipPeriod.objects.filter(
+            project=obj, end_date__gte=today
+        ).order_by('-sponsorship_level__value', '-start_date')
+
+    def item_title(self, item):
+        """Return the title of the sponsor.
+
+        :param item: Sponsorship period object of a project
+        :type item: Sponsorship period
+
+        :returns: name of the sponsor
+        :rtype: str
+        """
+        return item.sponsor.name
+
+    def item_description(self, item):
+        """Return the description of the sponsor.
+
+        :param item: Sponsorship period object of a project
+        :type item: Sponsorship period
+
+        :returns: description of the sponsor
+        :rtype: str
+        """
+        return ''
+
+    def item_extra_kwargs(self, item):
+        return {
+            'image_url': item.sponsor.logo.url,
+            'sponsor_level': item.sponsorship_level.name,
+            'sponsor_country': item.sponsor.country.name,
+            'sponsor_url': item.sponsor.sponsor_url,
+            'start_date': item.start_date.strftime('%d %B %Y'),  # '%d %B %Y' => "16 March 2019"
+            'end_date': item.end_date.strftime('%d %B %Y')     # '%Y%m%d'   => "20181012"
+        }
+


### PR DESCRIPTION
Earlier json was based on rss feed, but to be able to make better
use of the json items it is now base on feed only

Now the json feed returns items like:

```
description	""
end_date	"12 October 2019"
title	"QGIS user group Denmark"
sponsor_level	"Gold"
sponsor_url	"http://www.qgis.dk/"
image_url
"http://changelog.kartoza.com/media/images/projects/a6678418323905fba4f0647c8948dedc61c5c533.png"
sponsor_country	"Denmark"
link	"http://changelog.kartoza.com/en/qgis/sponsorshipperiod/ioqnil/"
guid	"http://changelog.kartoza.com/en/qgis/sponsorshipperiod/ioqnil/"
start_date	"12 October 2018"
```
which can then be used in qgis.org to create custom html based on that fields (instead of being dependent on the description html from the atom/rss feeds).
