### PR TITLE
add status and remarks for certification review process

### DIFF
--- a/deployment/docker/REQUIREMENTS.txt
+++ b/deployment/docker/REQUIREMENTS.txt
@@ -36,3 +36,4 @@ django-modeltranslation==0.12.2
 django-colorfield
 WeasyPrint==0.42.3
 djangorestframework==3.6.4
+django-simple-history==1.9.1

--- a/deployment/docker/REQUIREMENTS.txt
+++ b/deployment/docker/REQUIREMENTS.txt
@@ -35,3 +35,4 @@ xhtml2pdf==0.2b1
 django-modeltranslation==0.12.2
 django-colorfield
 WeasyPrint==0.42.3
+djangorestframework==3.6.4

--- a/django_project/certification/admin.py
+++ b/django_project/certification/admin.py
@@ -130,7 +130,8 @@ class CertifyingOrganisationAdmin(admin.ModelAdmin):
     filter_horizontal = ('organisation_owners',)
     search_fields = ['name']
     list_display = (
-        'name', 'country', 'project', 'approved', 'rejected', 'status', 'remarks'
+        'name', 'country', 'project',
+        'approved', 'rejected', 'status', 'remarks'
     )
     list_filter = ('country', 'approved', 'rejected', 'status')
 

--- a/django_project/certification/admin.py
+++ b/django_project/certification/admin.py
@@ -130,7 +130,7 @@ class CertifyingOrganisationAdmin(admin.ModelAdmin):
     filter_horizontal = ('organisation_owners',)
     search_fields = ['name']
     list_display = (
-        'name', 'country', 'approved', 'rejected', 'status', 'remarks'
+        'name', 'country', 'project', 'approved', 'rejected', 'status', 'remarks'
     )
     list_filter = ('country', 'approved', 'rejected', 'status')
 

--- a/django_project/certification/admin.py
+++ b/django_project/certification/admin.py
@@ -11,6 +11,7 @@ from certification.models.attendee import Attendee
 from certification.models.course_attendee import CourseAttendee
 from certification.models.certifying_organisation import CertifyingOrganisation
 from certification.models.status import Status
+from simple_history.admin import SimpleHistoryAdmin
 
 
 class CertificateAdmin(admin.ModelAdmin):
@@ -124,7 +125,7 @@ class CourseConvenerAdmin(admin.ModelAdmin):
         return query_set
 
 
-class CertifyingOrganisationAdmin(admin.ModelAdmin):
+class CertifyingOrganisationAdmin(SimpleHistoryAdmin):
     """Certifying organisation admin model."""
 
     filter_horizontal = ('organisation_owners',)
@@ -134,6 +135,7 @@ class CertifyingOrganisationAdmin(admin.ModelAdmin):
         'approved', 'rejected', 'status', 'remarks'
     )
     list_filter = ('country', 'approved', 'rejected', 'status')
+    history_list_display = ['status', 'remarks']
 
     def queryset(self, request):
         """Ensure we use the correct manager.

--- a/django_project/certification/admin.py
+++ b/django_project/certification/admin.py
@@ -10,6 +10,7 @@ from certification.models.course_type import CourseType
 from certification.models.attendee import Attendee
 from certification.models.course_attendee import CourseAttendee
 from certification.models.certifying_organisation import CertifyingOrganisation
+from certification.models.status import Status
 
 
 class CertificateAdmin(admin.ModelAdmin):
@@ -128,8 +129,10 @@ class CertifyingOrganisationAdmin(admin.ModelAdmin):
 
     filter_horizontal = ('organisation_owners',)
     search_fields = ['name']
-    list_display = ('name', 'country', 'approved', 'rejected')
-    list_filter = ('country', 'approved', 'rejected')
+    list_display = (
+        'name', 'country', 'approved', 'rejected', 'status', 'remarks'
+    )
+    list_filter = ('country', 'approved', 'rejected', 'status')
 
     def queryset(self, request):
         """Ensure we use the correct manager.
@@ -143,6 +146,10 @@ class CertifyingOrganisationAdmin(admin.ModelAdmin):
         return query_set
 
 
+class StatusAdmin(admin.ModelAdmin):
+    list_display = ('name', 'project','order')
+
+
 admin.site.register(Certificate, CertificateAdmin)
 admin.site.register(Attendee, AttendeeAdmin)
 admin.site.register(Course, CourseAdmin)
@@ -151,3 +158,4 @@ admin.site.register(TrainingCenter, TrainingCenterAdmin)
 admin.site.register(CourseConvener, CourseConvenerAdmin)
 admin.site.register(CertifyingOrganisation, CertifyingOrganisationAdmin)
 admin.site.register(CourseAttendee, CourseAttendeeAdmin)
+admin.site.register(Status, StatusAdmin)

--- a/django_project/certification/admin.py
+++ b/django_project/certification/admin.py
@@ -147,7 +147,7 @@ class CertifyingOrganisationAdmin(admin.ModelAdmin):
 
 
 class StatusAdmin(admin.ModelAdmin):
-    list_display = ('name', 'project','order')
+    list_display = ('name', 'project', 'order')
 
 
 admin.site.register(Certificate, CertificateAdmin)

--- a/django_project/certification/api_views/__init__.py
+++ b/django_project/certification/api_views/__init__.py
@@ -1,0 +1,1 @@
+# coding=utf-8

--- a/django_project/certification/api_views/get_status.py
+++ b/django_project/certification/api_views/get_status.py
@@ -1,0 +1,31 @@
+# coding=utf-8
+from braces.views import LoginRequiredMixin
+from django.http import HttpResponse
+from rest_framework import serializers, status
+from rest_framework.views import APIView, Response
+from base.models.project import Project
+from ..models.status import Status
+
+
+class StatusSerializer(serializers.ModelSerializer):
+    """Serializer for model Status."""
+
+    class Meta:
+        model = Status
+        fields = '__all__'
+
+
+class GetStatus(LoginRequiredMixin, APIView):
+    """API to get list of status."""
+
+    def get(self, request, project_slug):
+        try:
+            project = Project.objects.get(slug=project_slug)
+            status_qs = Status.objects.filter(project=project)
+            serializer = StatusSerializer(status_qs, many=True)
+            return Response(serializer.data)
+        except Project.DoesNotExist:
+            return HttpResponse(
+                'Project does not exist.',
+                status=status.HTTP_400_BAD_REQUEST
+            )

--- a/django_project/certification/api_views/update_status.py
+++ b/django_project/certification/api_views/update_status.py
@@ -1,0 +1,41 @@
+# coding=utf-8
+from braces.views import LoginRequiredMixin
+from django.http import HttpResponse
+from rest_framework import status
+from rest_framework.views import APIView, Response
+from ..models.certifying_organisation import CertifyingOrganisation
+from ..models.status import Status
+
+
+class UpdateStatusOrganisation(LoginRequiredMixin, APIView):
+    """API to update the status of an organisation."""
+
+    def post(self, request, project_slug, slug):
+        try:
+            certifyingorganisation = \
+                CertifyingOrganisation.objects.get(slug=slug)
+            status_id = request.POST.get('status', None)
+            remarks = request.POST.get('remarks', '')
+            certifyingorganisation.remarks = remarks
+
+            if status_id:
+                try:
+                    status_qs = Status.objects.get(id=status_id)
+                    certifyingorganisation.status=status_qs
+
+                    if status_qs.name.lower() == 'approved':
+                        certifyingorganisation.approved = True
+                except Status.DoesNotExist:
+                    return HttpResponse(
+                        'Status object does not exist.',
+                        status=status.HTTP_400_BAD_REQUEST
+                    )
+
+            certifyingorganisation.save()
+            return Response({'success': True})
+
+        except CertifyingOrganisation.DoesNotExist:
+            return HttpResponse(
+                'Certifying Organisation does not exist.',
+                status=status.HTTP_400_BAD_REQUEST
+            )

--- a/django_project/certification/api_views/update_status.py
+++ b/django_project/certification/api_views/update_status.py
@@ -21,7 +21,7 @@ class UpdateStatusOrganisation(LoginRequiredMixin, APIView):
             if status_id:
                 try:
                     status_qs = Status.objects.get(id=status_id)
-                    certifyingorganisation.status=status_qs
+                    certifyingorganisation.status = status_qs
 
                     if status_qs.name.lower() == 'approved':
                         certifyingorganisation.approved = True

--- a/django_project/certification/management/__init__.py
+++ b/django_project/certification/management/__init__.py
@@ -1,0 +1,1 @@
+# coding=utf-8

--- a/django_project/certification/management/commands/__init__.py
+++ b/django_project/certification/management/commands/__init__.py
@@ -1,0 +1,1 @@
+# coding=utf-8

--- a/django_project/certification/management/commands/set_status_existing_organisation.py
+++ b/django_project/certification/management/commands/set_status_existing_organisation.py
@@ -1,0 +1,89 @@
+# coding=utf-8
+"""Command to set the value of the Status of the Certifying Organisation.
+This command also creates Status Approved, In Progress and Rejected,
+if those status aren't created on the database yet.
+
+"""
+
+from django.core.management.base import BaseCommand
+from ...models.certifying_organisation import CertifyingOrganisation
+from ...models.status import Status
+
+
+class Command(BaseCommand):
+    """Set the status of the existing certifying organisations and creates
+    Status objects for Pending, Approved and Rejected.
+
+    """
+
+    help = 'Set the status of the existing certifying ' \
+           'organisations and creates. Status objects for Pending, ' \
+           'Approved and Rejected.'
+
+    def handle(self, *args, **options):
+        print('Begin process....')
+        certifying_organisations = \
+            CertifyingOrganisation.objects.filter(status=None)
+
+        print(
+            'Begin process to set existing pending certifying organisations.'
+        )
+        # Set status for pending certifying organisations
+        pending_certifying_organisation = certifying_organisations.filter(
+            approved=False
+        )
+        for organisation in pending_certifying_organisation:
+            pending_status, created = Status.objects.get_or_create(
+                name='Pending',
+                project=organisation.project
+            )
+            organisation.status = pending_status
+            organisation.save()
+        print(
+            'Status of all existing pending certifying '
+            'organisations has been set to Pending'
+        )
+        print('------------------------------------------------------------')
+        print(
+            'Begin process to set existing approved certifying organisations.'
+        )
+
+        # Set status for approved certifying organisations
+        approved_certifying_organisation = certifying_organisations.filter(
+            approved=True
+        )
+        for organisation in approved_certifying_organisation:
+            approved_status, created = Status.objects.get_or_create(
+                name='Approved',
+                project=organisation.project
+            )
+            organisation.status = approved_status
+            organisation.save()
+
+        print(
+            'Status of all existing approved certifying '
+            'organisations has been set to Approved'
+        )
+        print('------------------------------------------------------------')
+        print(
+            'Begin process to set existing rejected certifying organisations.'
+        )
+
+        # Set status for rejected certifying organisations
+        rejected_certifying_organisation = certifying_organisations.filter(
+            rejected=True
+        )
+        for organisation in rejected_certifying_organisation:
+            rejected_status, created = Status.objects.get_or_create(
+                name='Rejected',
+                project=organisation.project
+            )
+            organisation.status = rejected_status
+            organisation.save()
+        print(
+            'Status of all existing approved certifying '
+            'organisations has been set to Rejected'
+        )
+        print('------------------------------------------------------------')
+        print('')
+        print('Process finished.')

--- a/django_project/certification/migrations/0021_auto_20190904_1205.py
+++ b/django_project/certification/migrations/0021_auto_20190904_1205.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0022_auto_20180702_0420'),
+        ('certification', '0020_auto_20190729_1634'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Status',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(help_text='Name of the status', max_length=200)),
+                ('order', models.IntegerField(unique=True, null=True, blank=True)),
+                ('project', models.ForeignKey(to='base.Project')),
+            ],
+            options={
+                'ordering': ['order'],
+            },
+        ),
+        migrations.RenameField(
+            model_name='certifyingorganisation',
+            old_name='status',
+            new_name='remarks',
+        ),
+        migrations.AlterUniqueTogether(
+            name='status',
+            unique_together=set([('name', 'project')]),
+        ),
+    ]

--- a/django_project/certification/migrations/0022_auto_20190904_1205.py
+++ b/django_project/certification/migrations/0022_auto_20190904_1205.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('certification', '0021_auto_20190904_1205'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='certifyingorganisation',
+            name='status',
+            field=models.ForeignKey(to='certification.Status', null=True),
+        ),
+        migrations.AlterField(
+            model_name='certifyingorganisation',
+            name='remarks',
+            field=models.CharField(help_text='Remarks regarding status of this organisation, i.e. Rejected, because lacks of information', max_length=500, null=True, blank=True),
+        ),
+    ]

--- a/django_project/certification/migrations/0023_auto_20190904_1523.py
+++ b/django_project/certification/migrations/0023_auto_20190904_1523.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('certification', '0022_auto_20190904_1205'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='certifyingorganisation',
+            name='status',
+            field=models.ForeignKey(blank=True, to='certification.Status', null=True),
+        ),
+    ]

--- a/django_project/certification/migrations/0024_historicalcertifyingorganisation.py
+++ b/django_project/certification/migrations/0024_historicalcertifyingorganisation.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+import certification.models.certifying_organisation
+import django_countries.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0022_auto_20180702_0420'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('certification', '0023_auto_20190904_1523'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='HistoricalCertifyingOrganisation',
+            fields=[
+                ('id', models.IntegerField(verbose_name='ID', db_index=True, auto_created=True, blank=True)),
+                ('name', models.CharField(help_text='Name of organisation or institution', max_length=200)),
+                ('organisation_email', models.CharField(help_text='Email address organisation or institution.', max_length=200, validators=[certification.models.certifying_organisation.validate_email_address])),
+                ('url', models.URLField(help_text="Optional URL for the certifying organisation's home page", null=True, blank=True)),
+                ('address', models.TextField(help_text='Address of Organisation or Institution.', max_length=1000)),
+                ('logo', models.TextField(help_text='Logo for this organisation. Most browsers support dragging the image directly on to the "Choose File" button above.', max_length=100, blank=True)),
+                ('country', django_countries.fields.CountryField(blank=True, max_length=2, null=True, help_text='Select the country for this Institution')),
+                ('organisation_phone', models.CharField(help_text='Phone number: (country code)(number) e.g. +6221551553', max_length=200)),
+                ('organisation_credits', models.IntegerField(default=0, help_text='Credits available', null=True, blank=True)),
+                ('approved', models.BooleanField(default=False, help_text='Approval from project admin')),
+                ('enabled', models.BooleanField(default=True, help_text='Project enabled')),
+                ('rejected', models.BooleanField(default=False, help_text='Rejection from project admin')),
+                ('remarks', models.CharField(help_text='Remarks regarding status of this organisation, i.e. Rejected, because lacks of information', max_length=500, null=True, blank=True)),
+                ('slug', models.SlugField()),
+                ('history_id', models.AutoField(serialize=False, primary_key=True)),
+                ('history_date', models.DateTimeField()),
+                ('history_change_reason', models.CharField(max_length=100, null=True)),
+                ('history_type', models.CharField(max_length=1, choices=[('+', 'Created'), ('~', 'Changed'), ('-', 'Deleted')])),
+                ('history_user', models.ForeignKey(related_name='+', on_delete=django.db.models.deletion.SET_NULL, to=settings.AUTH_USER_MODEL, null=True)),
+                ('project', models.ForeignKey(related_name='+', on_delete=django.db.models.deletion.DO_NOTHING, db_constraint=False, blank=True, to='base.Project', null=True)),
+                ('status', models.ForeignKey(related_name='+', on_delete=django.db.models.deletion.DO_NOTHING, db_constraint=False, blank=True, to='certification.Status', null=True)),
+            ],
+            options={
+                'ordering': ('-history_date', '-history_id'),
+                'get_latest_by': 'history_date',
+                'verbose_name': 'historical certifying organisation',
+            },
+        ),
+    ]

--- a/django_project/certification/models/certifying_organisation.py
+++ b/django_project/certification/models/certifying_organisation.py
@@ -151,7 +151,8 @@ class CertifyingOrganisation(models.Model):
 
     status = models.ForeignKey(
         Status,
-        null=True
+        null=True,
+        blank=True
     )
 
     remarks = models.CharField(

--- a/django_project/certification/models/certifying_organisation.py
+++ b/django_project/certification/models/certifying_organisation.py
@@ -16,6 +16,7 @@ from unidecode import unidecode
 from django.contrib.auth.models import User
 from django_countries.fields import CountryField
 import logging
+from simple_history.models import HistoricalRecords
 from certification.utilities import check_slug
 from certification.models.status import Status
 
@@ -163,6 +164,8 @@ class CertifyingOrganisation(models.Model):
         null=True,
         blank=True
     )
+
+    history = HistoricalRecords()
 
     slug = models.SlugField()
     organisation_owners = models.ManyToManyField(User)

--- a/django_project/certification/models/certifying_organisation.py
+++ b/django_project/certification/models/certifying_organisation.py
@@ -17,6 +17,7 @@ from django.contrib.auth.models import User
 from django_countries.fields import CountryField
 import logging
 from certification.utilities import check_slug
+from certification.models.status import Status
 
 logger = logging.getLogger(__name__)
 
@@ -148,9 +149,14 @@ class CertifyingOrganisation(models.Model):
         default=False
     )
 
-    status = models.CharField(
+    status = models.ForeignKey(
+        Status,
+        null=True
+    )
+
+    remarks = models.CharField(
         help_text=_(
-            'Status of this organisation, '
+            'Remarks regarding status of this organisation, '
             'i.e. Rejected, because lacks of information'),
         max_length=500,
         null=True,

--- a/django_project/certification/models/status.py
+++ b/django_project/certification/models/status.py
@@ -1,0 +1,38 @@
+# coding=utf-8
+"""Model for status of the certifying organisation."""
+
+from django.db import models
+from django.utils.translation import ugettext_lazy as _
+from base.models.project import Project
+
+
+class Status(models.Model):
+    """Status model."""
+
+    name = models.CharField(
+        help_text=_('Name of the status'),
+        max_length=200,
+        null=False,
+        blank=False,
+    )
+
+    order = models.IntegerField(
+        blank=True,
+        null=True,
+        unique=True
+    )
+
+    project = models.ForeignKey(Project)
+
+    class Meta:
+        ordering = ['order']
+        unique_together = ['name', 'project']
+
+    def save(self, *args, **kwargs):
+        if not self.pk:
+            count = Status.objects.all().count()
+            self.order = count
+        super(Status, self).save(*args, **kwargs)
+
+    def __unicode__(self):
+        return '{}'.format(self.name)

--- a/django_project/certification/templates/certifying_organisation/pending-list.html
+++ b/django_project/certification/templates/certifying_organisation/pending-list.html
@@ -150,9 +150,11 @@
                      organisation_country="{{ certifyingorganisation.country.name }}"
                      organisation_slug="{{ certifyingorganisation.slug }}"
                      organisation_project_slug="{{ certifyingorganisation.project.slug }}"
-                     organisation_status="{{ certifyingorganisation.status }}"
+                     organisation_status="{{ certifyingorganisation.status.id }}"
+                     organisation_remarks="{{ certifyingorganisation.remarks }}"
                      data-title="Click to edit">
-                    <b>Status</b>: <span class="status-info">{{ certifyingorganisation.status }}</span>
+                    <b>Status</b>: <span class="status-info">{{ certifyingorganisation.status }}</span><br/>
+                    <b>Remarks</b>: <span class="remarks-info">{{ certifyingorganisation.remarks }}</span>
                 </div>
                 {% endif %}
             </div>
@@ -211,7 +213,10 @@
                     </ul>
                     <form id="updateStatusForm" role="form">
                         <label>Status:</label><br>
-                        <input name="update-status" class="form-control">
+                        <select name="update-status" class="form-control">
+                        </select><br/>
+                        <label>Remarks:</label><br>
+                        <input name="update-remarks" class="form-control">
                         <input name="status-organisation-slug" hidden>
                         <input name="status-organisation-project-slug" hidden>
                     </form>
@@ -255,11 +260,30 @@
         });
 
         $('.status-wrapper').click(function () {
+            var initial_status = $(this).attr('organisation_status');
+            var project_slug = $(this).attr('organisation_project_slug');
+            $.ajax({
+                url: '/{{ LANGUAGE_CODE }}/' + project_slug + '/get-status-list/',
+                method: 'GET',
+                success: function (data) {
+                    var $selectStatus = $('[name="update-status"]');
+                    $selectStatus.empty();
+                    $selectStatus.append('<option value="">--------------------------</option>');
+                    for(var i=0; i<data.length; i++){
+                        if(data[i].id === parseInt(initial_status)){
+                            $selectStatus.append('<option value=' + data[i].id + ' selected>' + data[i].name + '</option>')
+                        }else {
+                            $selectStatus.append('<option value=' + data[i].id + '>' + data[i].name + '</option>')
+                        }
+
+                    }
+                }
+            });
             $('#status-organisation-name').html($(this).attr('organisation_name'));
             $('#status-organisation-country').html($(this).attr('organisation_country'));
             $('[name=status-organisation-slug]').val($(this).attr('organisation_slug'));
-            $('[name=status-organisation-project-slug]').val($(this).attr('organisation_project_slug'));
-            $('[name=update-status]').val($(this).attr('organisation_status'));
+            $('[name=status-organisation-project-slug]').val(project_slug);
+            $('[name=update-remarks]').val($(this).attr('organisation_remarks'));
             $('#updateStatusModal').modal('show')
         });
 
@@ -279,8 +303,7 @@
             var organisation_slug = $('[name=rejected-organisation-slug]').val();
             var organisation_project_slug = $('[name=rejected-organisation-project-slug]').val();
             $.ajax({
-                url: '/' + organisation_project_slug + '/reject-certifyingorganisation/' + organisation_slug + '/',
-                type: 'GET',
+                url: '/{{ LANGUAGE_CODE }}/' + organisation_project_slug + '/reject-certifyingorganisation/' + organisation_slug + '/',
                 data: {
                     'status': $('[name=status]').val()
                 },
@@ -294,11 +317,13 @@
             var organisation_slug = $('[name=status-organisation-slug]').val();
             var organisation_project_slug = $('[name=status-organisation-project-slug]').val();
             $.ajax({
-                url: '/' + organisation_project_slug + '/update-status-certifyingorganisation/' + organisation_slug + '/',
-                type: 'GET',
+                url: '/{{ LANGUAGE_CODE }}/' + organisation_project_slug + '/update-status-certifyingorganisation/' + organisation_slug + '/',
+                method: 'POST',
                 data: {
-                    'status': $('[name=update-status]').val()
+                    'status': $('[name=update-status]').val(),
+                    'remarks': $('[name=update-remarks]').val()
                 },
+                dataType: 'json',
                 success: function(){
                      location.reload()
                 }

--- a/django_project/certification/tests/model_factories.py
+++ b/django_project/certification/tests/model_factories.py
@@ -11,7 +11,9 @@ from certification.models import (
     CourseConvener,
     CertifyingOrganisation,
     TrainingCenter,
-    CourseAttendee)
+    CourseAttendee,
+    Status
+)
 from core.model_factories import UserF
 from base.tests.model_factories import ProjectF
 
@@ -122,3 +124,13 @@ class CertificateF(factory.django.DjangoModelFactory):
     course = factory.SubFactory(CourseF)
     attendee = factory.SubFactory(AttendeeF)
     author = factory.SubFactory(UserF)
+
+
+class StatusF(factory.django.DjangoModelFactory):
+    """Certificate model factory."""
+
+    class Meta:
+        model = Status
+
+    name = factory.sequence(lambda n: u'Test status %s' % n)
+    project = factory.SubFactory(ProjectF)

--- a/django_project/certification/tests/test_models.py
+++ b/django_project/certification/tests/test_models.py
@@ -10,7 +10,9 @@ from certification.tests.model_factories import (
     CourseConvenerF,
     CertifyingOrganisationF,
     TrainingCenterF,
-    CourseAttendeeF)
+    CourseAttendeeF,
+    StatusF
+)
 
 
 class TestCertifyingOrganisation(TestCase):
@@ -360,3 +362,44 @@ class TestCourseAttendee(TestCase):
 
         # check if deleted.
         self.assertTrue(model.pk is None)
+
+
+class TestStatus(TestCase):
+    """Test status model."""
+
+    def setUp(self):
+        """Set up before test."""
+
+        pass
+
+    def test_Status_create(self):
+        """Test status model creation."""
+
+        model = StatusF.create()
+
+        # check if PK exists.
+        self.assertTrue(model.pk is not None)
+
+    def test_Status_delete(self):
+        """Test status model deletion."""
+
+        model = StatusF.create()
+        model.delete()
+
+        # check if deleted.
+        self.assertTrue(model.pk is None)
+
+    def test_Status_update(self):
+        """Test status model update."""
+
+        model = StatusF.create()
+        new_model_data = {
+            'name': 'new Status name',
+        }
+        model.__dict__.update(new_model_data)
+        model.save()
+
+        # check if updated.
+        for key, val in new_model_data.items():
+            self.assertEqual(model.__dict__.get(key), val)
+            self.assertTrue(model.name == 'new Status name')

--- a/django_project/certification/tests/views/test_certifying_organisation_views.py
+++ b/django_project/certification/tests/views/test_certifying_organisation_views.py
@@ -124,7 +124,7 @@ class TestCertifyingOrganisationView(TestCase):
         status = self.client.login(username='anita', password='password')
         self.assertTrue(status)
         post_data = {
-            'status': 'test update status'
+            'remarks': 'test update status'
         }
         self.assertEqual(self.pending_certifying_organisation.approved, False)
         response = self.client.get(
@@ -136,5 +136,5 @@ class TestCertifyingOrganisationView(TestCase):
         self.assertEqual(response.status_code, 302)
         self.pending_certifying_organisation.refresh_from_db()
         self.assertEqual(
-            self.pending_certifying_organisation.status, 'test update status')
+            self.pending_certifying_organisation.remarks, 'test update status')
         self.assertEqual(self.pending_certifying_organisation.approved, False)

--- a/django_project/certification/tests/views/test_certifying_organisation_views.py
+++ b/django_project/certification/tests/views/test_certifying_organisation_views.py
@@ -143,3 +143,27 @@ class TestCertifyingOrganisationView(TestCase):
         self.assertEqual(
             self.pending_certifying_organisation.status, status_object)
         self.assertEqual(self.pending_certifying_organisation.approved, False)
+
+    @override_settings(VALID_DOMAIN=['testserver', ])
+    def test_get_status_list_no_login(self):
+        response = self.client.get(
+            reverse('get-status-list', kwargs={
+                'project_slug': self.project.slug,
+            })
+        )
+        self.assertEqual(response.status_code, 302)
+
+    @override_settings(VALID_DOMAIN=['testserver', ])
+    def test_get_status_list_with_login(self):
+        status = self.client.login(username='anita', password='password')
+        self.assertTrue(status)
+        status_object = StatusF.create(
+            project=self.project
+        )
+        response = self.client.get(
+            reverse('get-status-list', kwargs={
+                'project_slug': self.project.slug,
+            })
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data[0]['name'], status_object.name)

--- a/django_project/certification/tests/views/test_certifying_organisation_views.py
+++ b/django_project/certification/tests/views/test_certifying_organisation_views.py
@@ -1,5 +1,7 @@
 # coding=utf-8
 import logging
+from StringIO import StringIO
+from django.core.management import call_command
 from django.test import TestCase, override_settings
 from django.test.client import Client
 from django.core.urlresolvers import reverse
@@ -167,3 +169,13 @@ class TestCertifyingOrganisationView(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data[0]['name'], status_object.name)
+
+    @override_settings(VALID_DOMAIN=['testserver', ])
+    def test_update_status_command(self):
+        out = StringIO()
+        call_command('set_status_existing_organisation', stdout=out)
+        self.certifying_organisation.refresh_from_db()
+        self.pending_certifying_organisation.refresh_from_db()
+        self.assertEquals(self.certifying_organisation.status.name, 'Approved')
+        self.assertEquals(
+            self.pending_certifying_organisation.status.name, 'Pending')

--- a/django_project/certification/urls.py
+++ b/django_project/certification/urls.py
@@ -12,7 +12,6 @@ from views import (
     PendingCertifyingOrganisationListView,
     ApproveCertifyingOrganisationView,
     reject_certifying_organisation,
-    update_status_certifying_organisation,
     RejectedCertifyingOrganisationListView,
 
     # Course Type.
@@ -64,6 +63,8 @@ from views import (
     # About.
     AboutView,
 )
+from api_views.get_status import GetStatus
+from api_views.update_status import UpdateStatusOrganisation
 
 
 urlpatterns = patterns(
@@ -89,7 +90,7 @@ urlpatterns = patterns(
         name='certifyingorganisation-reject'),
     url(regex='^(?P<project_slug>[\w-]+)/update-status-certifyingorganisation/'
               '(?P<slug>[\w-]+)/$',
-        view=update_status_certifying_organisation,
+        view=UpdateStatusOrganisation.as_view(),
         name='certifyingorganisation-update-status'),
     url(regex='^(?P<project_slug>[\w-]+)/'
               'certifyingorganisation/rejected-list/$',
@@ -267,4 +268,8 @@ urlpatterns = patterns(
     # Search.
     url(regex='^(?P<project_slug>[\w-]+)/certificate/$',
         view=ValidateCertificate.as_view(), name='validate-certificate'),
+
+    # API Views
+    url(regex='^(?P<project_slug>[\w-]+)/get-status-list/$',
+        view=GetStatus.as_view(), name='get-status-list'),
 )

--- a/django_project/certification/views/certifying_organisation.py
+++ b/django_project/certification/views/certifying_organisation.py
@@ -892,33 +892,6 @@ def reject_certifying_organisation(request, **kwargs):
         return HttpResponse('Please use GET method.')
 
 
-def update_status_certifying_organisation(request, **kwargs):
-    """Function to update status of a certifying organisation."""
-
-    pattern_name = 'pending-certifyingorganisation-list'
-
-    if request.method == 'GET':
-        project_slug = kwargs.pop('project_slug')
-        slug = kwargs.pop('slug')
-
-        try:
-            certifyingorganisation = \
-                CertifyingOrganisation.objects.get(slug=slug)
-            status = request.GET.get('status', '')
-            certifyingorganisation.status = status
-
-            certifyingorganisation.save()
-        except:   # noqa
-            HttpResponse('Certifying organisation is not found.')
-
-        url = reverse(pattern_name, kwargs={
-            'project_slug': project_slug
-        })
-        return HttpResponseRedirect(url)
-    else:
-        return HttpResponse('Please use GET method.')
-
-
 class RejectedCertifyingOrganisationListView(
         LoginRequiredMixin,
         CertifyingOrganisationMixin,

--- a/django_project/certification/views/certifying_organisation.py
+++ b/django_project/certification/views/certifying_organisation.py
@@ -835,8 +835,8 @@ def reject_certifying_organisation(request, **kwargs):
         certifyingorganisation.rejected = True
         certifyingorganisation.approved = False
 
-        status = request.GET.get('status', '')
-        certifyingorganisation.status = status
+        remarks = request.GET.get('remarks', '')
+        certifyingorganisation.remarks = remarks
 
         # Check if slug have duplicates in rejected objects.
         # If there is duplicate slug, assign new slug.

--- a/django_project/core/custom_middleware.py
+++ b/django_project/core/custom_middleware.py
@@ -39,6 +39,8 @@ class NavContextMiddleware(object):
         :return: context :rtype: dict
         """
         context = response.context_data
+        if not context:
+            return response
 
         if context.get('project', None):
             context['the_project'] = context.get('project')

--- a/django_project/core/settings/base.py
+++ b/django_project/core/settings/base.py
@@ -123,6 +123,7 @@ MIDDLEWARE_CLASSES = (
     'core.custom_middleware.CheckDomainMiddleware',
     # Uncomment the next line for simple clickjacking protection:
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'simple_history.middleware.HistoryRequestMiddleware',
 )
 
 ROOT_URLCONF = 'core.urls'

--- a/django_project/core/settings/contrib.py
+++ b/django_project/core/settings/contrib.py
@@ -23,7 +23,8 @@ INSTALLED_APPS += (
     'colorfield',  # for color picker
     # 'user_map',
     'disqus',
-    'rest_framework'
+    'rest_framework',
+    'simple_history',
 )
 
 # Set disqus and shortname

--- a/django_project/core/settings/contrib.py
+++ b/django_project/core/settings/contrib.py
@@ -23,6 +23,7 @@ INSTALLED_APPS += (
     'colorfield',  # for color picker
     # 'user_map',
     'disqus',
+    'rest_framework'
 )
 
 # Set disqus and shortname


### PR DESCRIPTION
This PR:
- [x] Add Status model, where admin can add/edit/remove status for reviewing certifying organisation. 
- [x] In pending certifying organisation view, we can edit the status of a certifying organisation and give remarks.

Editing status and remarks
![Peek 2019-09-04 19-32](https://user-images.githubusercontent.com/26101337/64256195-23b4e580-cf4d-11e9-915a-840679d63177.gif)

We can also approve the organisation from this form as long as we have approved status on the list
![Peek 2019-09-04 19-32 2](https://user-images.githubusercontent.com/26101337/64256210-2dd6e400-cf4d-11e9-9016-64340c04f77f.gif)

Status can be added/edited/removed from admin. 
The order number is the order that will be displayed in the form.
The Status has foreign key with project and it's name is unique within the project (name and project are unique together).
![Peek 2019-09-04 19-33](https://user-images.githubusercontent.com/26101337/64256246-41824a80-cf4d-11e9-9538-f7e4207e8151.gif)

After updating the Status model in admin, we can see in front end.
![Peek 2019-09-04 19-40](https://user-images.githubusercontent.com/26101337/64256298-61197300-cf4d-11e9-94dc-15beee09dab8.gif)


