### PR TITLE
change sponsor to sustaining member

### DIFF
--- a/django_project/base/templates/project/new_detail.html
+++ b/django_project/base/templates/project/new_detail.html
@@ -78,10 +78,10 @@
         </div>
         <div class="col-md-4">
             <div class="panel panel-default custom-panel clickable-panel" onclick="window.location='sponsors/list/';">
-                <h3>Sponsors</h3>
+                <h3>Sustaining Members</h3>
             {% if sponsors %}
                 <h6 class="text-muted">
-                    View Our Project Sponsors
+                    View Our Project Sustaining Members
                 </h6>
                 <div class="content-list">
                 {% for sponsor in sponsors %}
@@ -99,7 +99,7 @@
                 </div>
             {% else %}
                 {% if user.is_staff or user == project.owner %}
-                    <h6>No sponsors are defined, but you can
+                    <h6>No sustaining members are defined, but you can
                     <span>
                         <a
                           class="btn btn-default btn-mini" id="action_text"

--- a/django_project/changes/templates/sponsor/create.html
+++ b/django_project/changes/templates/sponsor/create.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block page_title %}
-    <h1>Add Sponsor</h1>
+    <h1>Add Sustaining Member</h1>
 {% endblock page_title %}
 
 {% block content %}

--- a/django_project/changes/templates/sponsor/delete.html
+++ b/django_project/changes/templates/sponsor/delete.html
@@ -1,20 +1,20 @@
 {% extends "project_base.html" %}
 {% load custom_markup %}
 
-{% block title %}Sponsor Deleted - {{ block.super }}{% endblock %}
+{% block title %}Sustaining Member Deleted - {{ block.super }}{% endblock %}
 
 {% block extra_head %}
 {% endblock %}
 
 {% block page_title %}
-    <h1>Sponsor Deleted</h1>
+    <h1>Sustaining Member Deleted</h1>
 {% endblock page_title %}
 
 {% block content %}
     <form action="" id="delete-confirmation" method="post">{% csrf_token %}
         <div class="alert row">
             <div class="col-lg-10">
-                <p class="lead">Please confirm you wish to delete the sponsor below!</p>
+                <p class="lead">Please confirm you wish to delete the sustaining member below!</p>
             </div>
             <div class="col-lg-2">
                 <div class="btn-group">
@@ -34,7 +34,7 @@
         </div>
         <div class="row">
             <div class="col-lg-12">
-                <h3>Sponsor: {{ sponsor.name }}</h3>
+                <h3>Sustaining Member: {{ sponsor.name }}</h3>
             </div>
         </div>
         <div class="row">

--- a/django_project/changes/templates/sponsor/detail.html
+++ b/django_project/changes/templates/sponsor/detail.html
@@ -1,13 +1,13 @@
 {% extends "project_base.html" %}
 {% load custom_markup %}
 
-{% block title %}Sponsors - {{ block.super }}{% endblock %}
+{% block title %}Sustaining Members - {{ block.super }}{% endblock %}
 
 {% block extra_head %}
 {% endblock %}
 
 {% block page_title %}
-    <h1>Sponsors (all)</h1>
+    <h1>Sustaining Members (all)</h1>
 {% endblock page_title %}
 
 {% block content %}
@@ -121,7 +121,7 @@
                 {% if sponsor.sponsor.agreement and user.is_authenticated %}
                     <p>
                         <div class="sponsor-detail-title">
-                            Sponsor agreement
+                            Sustaining Member agreement
                         </div>
                         <div>
                             <b><a href="{{ sponsor.agreement.url }}"> Document agreement</a></b>
@@ -131,7 +131,7 @@
                 {% if sponsor.amount_sponsored and sponsor.currency %}
                     <p>
                         <div class="sponsor-detail-title">
-                            Amount Sponsored
+                            Amount Contributed
                         </div>
                         <div>
                             {{ sponsor.amount_sponsored }} {{ sponsor.currency }}

--- a/django_project/changes/templates/sponsor/list.html
+++ b/django_project/changes/templates/sponsor/list.html
@@ -2,13 +2,13 @@
 {% load thumbnail %}
 {% load custom_markup %}
 {% load staticfiles %}
-{% block title %}Sponsors - {{ block.super }}{% endblock %}
+{% block title %}Sustaining Members - {{ block.super }}{% endblock %}
 
 {% block extra_head %}
 {% endblock %}
 
 {% block page_title %}
-    <h1 xmlns="http://www.w3.org/1999/html">Sponsors (all)</h1>
+    <h1 xmlns="http://www.w3.org/1999/html">Sustaining Members (all)</h1>
 {% endblock page_title %}
 
 {% block content %}
@@ -25,51 +25,51 @@
     </style>
     <div class="page-header">
         <h1 class="text-muted">
-            {% if unapproved %}Unapproved {% endif %}Sponsors
+            {% if unapproved %}Unapproved {% endif %}Sustaining Members
                 <div class="pull-right btn-group">
                 {% if user.is_authenticated %}
                     {% if user.is_staff or user == the_project.owner or user in the_project.sponsorship_managers.all %}
                         <a class="btn btn-default btn-mini tooltip-toggle icon"
                            href='{% url "sponsor-create" project_slug %}'
-                           data-title="Create New Sponsor">
+                           data-title="Create New Sustaining Member">
                             {% show_button_icon "add" %}
                         </a>
                     {% endif %}
                     {% if not unapproved %}
                         <a class="btn btn-default btn-mini tooltip-toggle icon"
                            href='{% url "pending-sponsor-list" project_slug %}'
-                           data-title="View Pending sponsorship period">
+                           data-title="View Pending Sustaining Membership period">
                             <span class="glyphicon glyphicon-time"></span>
                         </a>
                     {% endif %}
                   <a class="btn btn-default btn-mini tooltip-toggle icon"
                        href='{% url "sponsor-cloud" project_slug %}'
-                       data-title="Generate Current Sponsor Cloud">
+                       data-title="Generate Current Sustaining Member Cloud">
                         <i class="glyphicon glyphicon-cloud"></i>
                     </a>
                 {% endif %}
                     <a class="btn btn-default btn-mini tooltip-toggle icon"
                        href='{% url "sponsor-programme" project_slug %}'
-                       data-title="View Sponsorship Programme">
+                       data-title="View Sustaining Membership Programme">
                         <i class="glyphicon glyphicon-info-sign"></i></a>
                     <a class="btn btn-default btn-mini tooltip-toggle rss-icon"
                        href='{% url "sponsor-rss-feed" project_slug %}'
-                       data-title="RSS Feed for Sponsors">
+                       data-title="RSS Feed for Sustaining Members">
                         <i class="fa fa-rss-square"></i>
                     </a>
                     <a class="btn btn-default btn-mini tooltip-toggle rss-icon"
                        href='{% url "sponsor-atom-feed" project_slug %}'
-                       data-title="Atom Feed for Sponsors">
+                       data-title="Atom Feed for Sustaining Members">
                         <i class="fa fa-rss"></i>
                     </a>
                     <a class="btn btn-default btn-mini tooltip-toggle json-feed"
                        href='{% url "sponsor-json-feed" project_slug %}'
-                       data-title="JSON Feed for Sponsors">
+                       data-title="JSON Feed for Sustaining Members">
                         <i class="fa fa-rss-square"></i>
                     </a>
                     <a class="btn btn-default btn-mini tooltip-toggle rss-icon"
                        href='{% url "past-sponsor-rss-feed" project_slug %}'
-                       data-title="RSS Feed for Past Sponsors">
+                       data-title="RSS Feed for Past Sustaining Members">
                         <i class="fa fa-rss-square" style="font-weight: bold"></i>
                     </a>
                 </div>
@@ -77,13 +77,13 @@
     </div>
     {% ifequal num_sponsors 0 %}
         {% if unapproved %}
-            <h3>All sponsors are approved.</h3>
+            <h3>All sustaining members are approved.</h3>
         {% else %}
-            <h3>No sponsors are defined.</h3>
+            <h3>No sustaining members are defined.</h3>
         {% endif %}
     {% endifequal %}
 
-    {% if sponsors %}<h2 class="text-muted">List of Current Sponsors</h2> {% endif %}
+    {% if sponsors %}<h2 class="text-muted">List of Current Sustaining Members</h2> {% endif %}
 
 
     {% for sponsor in sponsors %}
@@ -117,7 +117,7 @@
 
                         <h5>{{ sponsor.sponsorship_level }}</h5>
                         {% ifnotequal sponsor.amount_sponsored None %}
-                        <h5>Amount sponsored : {{ sponsor.amount_sponsored }} {{ sponsor.currency }}</h5>
+                        <h5>Amount contributed : {{ sponsor.amount_sponsored }} {{ sponsor.currency }}</h5>
                         {% endifnotequal %}
                     </div>
                     <div class="col-lg-2">
@@ -136,7 +136,7 @@
 
 
     {% if sponsors %}
-        <hr/><h2 class="text-muted">List of Past Sponsors</h2> {% endif %}
+        <hr/><h2 class="text-muted">List of Past Sustaining Members</h2> {% endif %}
 
 
     {% for sponsor in sponsors %}

--- a/django_project/changes/templates/sponsor/pending-list.html
+++ b/django_project/changes/templates/sponsor/pending-list.html
@@ -1,20 +1,20 @@
 {% extends "project_base.html" %}
 {% load thumbnail %}
 {% load custom_markup %}
-{% block title %}Sponsors - {{ block.super }}{% endblock %}
+{% block title %}Sustaining Members - {{ block.super }}{% endblock %}
 
 {% block extra_head %}
 {% endblock %}
 
 {% block page_title %}
-    <h1>Sponsors (all)</h1>
+    <h1>Sustaining Members (all)</h1>
 {% endblock page_title %}
 
 {% block content %}
     <div class="page-header">
         <h1 class="text-muted">
             {% if unapproved %}Unapproved {% endif %}
-            Sponsors
+            Sustaining Members
             {% if user.is_authenticated %}
                 {% if user.is_staff or user == project.owner or user in project.sponsorship_managers.all %}
                     <div class="pull-right btn-group">
@@ -37,9 +37,9 @@
     </div>
     {% ifequal num_sponsors 0 %}
         {% if unapproved %}
-            <h3>All sponsors are approved.</h3>
+            <h3>All sustaining members are approved.</h3>
         {% else %}
-            <h3>No sponsors are defined, but you can <a
+            <h3>No sustaining members are defined, but you can <a
                     class="btn btn-default btn-mini"
                     href='{% url "sponsor-create" project_slug %}'>create one</a>.</h3>
         {% endif %}

--- a/django_project/changes/templates/sponsor/renewed.html
+++ b/django_project/changes/templates/sponsor/renewed.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block page_title %}
-    <h1>Renewed Sponsor</h1>
+    <h1>Renewed Sustaining Member</h1>
 {% endblock page_title %}
 
 {% block content %}

--- a/django_project/changes/templates/sponsor/sponsor_cloud.html
+++ b/django_project/changes/templates/sponsor/sponsor_cloud.html
@@ -1,13 +1,13 @@
 {% extends "project_base.html" %}
 {% load custom_markup %}
 
-{% block title %}Sponsor Cloud{% endblock %}
+{% block title %}Sustaining Member Cloud{% endblock %}
 
 {% block extra_head %}
 {% endblock %}
 
 {% block page_title %}
-    <h1>Sponsor Cloud</h1>
+    <h1>Sustaining Member Cloud</h1>
 {% endblock page_title %}
 
 {% block content %}
@@ -21,7 +21,7 @@
     {% if image != 'none' %}
         <img style="border: 2px solid #F5F5F5" src="{{ image.url }}">
     {% else %}
-        <h3>No current sponsor found</h3>
+        <h3>No current sustaining member found</h3>
     {% endif %}
     </div>
 

--- a/django_project/changes/templates/sponsor/update.html
+++ b/django_project/changes/templates/sponsor/update.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block page_title %}
-    <h1>Add sponsor</h1>
+    <h1>Add Sustaining Member</h1>
 {% endblock page_title %}
 
 {% block content %}

--- a/django_project/changes/templates/sponsor/world-map.html
+++ b/django_project/changes/templates/sponsor/world-map.html
@@ -17,7 +17,7 @@
 
             options_array = [
                 {
-                    'display' : 'Sponsor Count',
+                    'display' : 'Sustaining Member Count',
                     'value' : 'sponsor_total',
                     'grades' : [0, 1, 2, 3, 4, 5],
                     'attr' : ''
@@ -101,7 +101,7 @@
 
             // method that we will use to update the control based on feature properties passed
             info.update = function (props) {
-                var info_title = '<h4>Sponsor Info</h4>';
+                var info_title = '<h4>Sustaining Member Info</h4>';
                 var info_content = '';
 
                 if (props) {
@@ -302,14 +302,14 @@
 {% block title %} World Map {% endblock %}
 
 {% block page_title %}
-    <h1>World Map of Sponsors</h1>
+    <h1>World Map of Sustaining Members</h1>
 {% endblock page_title %}
 
 {% block content %}
 
     <div class="map-wrapper">
         <div class="container">
-            <h1>World Map of Sponsors</h1>
+            <h1>World Map of Sustaining Members</h1>
         </div>
         <div class="container">
             <div class="container-fluid">

--- a/django_project/changes/templates/sponsorship_level/create.html
+++ b/django_project/changes/templates/sponsorship_level/create.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block page_title %}
-<h1>Add Sponsorship Level</h1>
+<h1>Add Sustaining Membership Level</h1>
 {% endblock page_title %}
 
 {% block content %}

--- a/django_project/changes/templates/sponsorship_level/delete.html
+++ b/django_project/changes/templates/sponsorship_level/delete.html
@@ -1,20 +1,20 @@
 {% extends "project_base.html" %}
 {% load custom_markup %}
 
-{% block title %}Sponsorship Level Deleted - {{ block.super }}{% endblock %}
+{% block title %}Sustaining Membership Level Deleted - {{ block.super }}{% endblock %}
 
 {% block extra_head %}
 {% endblock %}
 
 {% block page_title %}
-  <h1>Sponsorship Level Deleted</h1>
+  <h1>Sustaining Membership Level Deleted</h1>
 {% endblock page_title %}
 
 {% block content %}
   <form action="" id="delete-confirmation" method="post">{% csrf_token %}
     <div class="alert row">
       <div class="col-lg-10">
-        <p class="lead">Please confirm you wish to delete the sponsorship level below!</p>
+        <p class="lead">Please confirm you wish to delete the Sustaining Membership level below!</p>
       </div>
       <div class="col-lg-2">
         <div class="btn-group pull-right">
@@ -34,7 +34,7 @@
     </div>
     <div class="row">
       <div class="col-lg-12">
-        <h3>Sponsorship Level: {{ sponsorshiplevel.name }}</h3>
+        <h3>Sustaining Membership Level: {{ sponsorshiplevel.name }}</h3>
       </div>
     </div>
     <div class="row">

--- a/django_project/changes/templates/sponsorship_level/detail.html
+++ b/django_project/changes/templates/sponsorship_level/detail.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block page_title %}
-  <h1>Sponsor Levels (all)</h1>
+  <h1>Sustaining Member Levels (all)</h1>
 {% endblock page_title %}
 
 {% block content %}

--- a/django_project/changes/templates/sponsorship_level/list.html
+++ b/django_project/changes/templates/sponsorship_level/list.html
@@ -1,20 +1,20 @@
 {% extends "project_base.html" %}
 {% load thumbnail %}
 {% load custom_markup %}
-{% block title %}Sponsorship Levels - {{ block.super }}{% endblock %}
+{% block title %}Sustaining Membership Levels - {{ block.super }}{% endblock %}
 
 {% block extra_head %}
 {% endblock %}
 
 {% block page_title %}
-    <h1>Sponsorship levels (all)</h1>
+    <h1>Sustaining Membership levels (all)</h1>
 {% endblock page_title %}
 
 {% block content %}
     <div class="page-header">
         <h1 class="text-muted">
             {% if unapproved %}Unapproved {% endif %}
-            Sponsorship Levels
+            Sustaining Membership Levels
             {% if user.is_authenticated %}
                 {% if user.is_staff or user == project.owner or user in project.sponsorship_managers.all %}
                     <div class="pull-right btn-group">
@@ -37,9 +37,9 @@
     </div>
     {% ifequal num_sponsorshiplevels 0 %}
         {% if unapproved %}
-            <h3>All sponsorship level are approved.</h3>
+            <h3>All sustaining membership level are approved.</h3>
         {% else %}
-            <h3>No sponsorship level are defined, but you can <a
+            <h3>No sustaining membership level are defined, but you can <a
                     class="btn btn-default btn-mini"
                     href='{% url "sponsorshiplevel-create" project_slug %}'>create one</a>.</h3>
         {% endif %}

--- a/django_project/changes/templates/sponsorship_level/update.html
+++ b/django_project/changes/templates/sponsorship_level/update.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block page_title %}
-<h1>Add sponsorship level</h1>
+<h1>Add sustaining membership level</h1>
 {% endblock page_title %}
 
 {% block content %}

--- a/django_project/changes/templates/sponsorship_period/create.html
+++ b/django_project/changes/templates/sponsorship_period/create.html
@@ -19,7 +19,7 @@
 {% endblock %}
 
 {% block page_title %}
-<h1>Add Sponsorship Period</h1>
+<h1>Add Sustaining Membership Period</h1>
 {% endblock page_title %}
 
 {% block content %}

--- a/django_project/changes/templates/sponsorship_period/delete.html
+++ b/django_project/changes/templates/sponsorship_period/delete.html
@@ -1,20 +1,20 @@
 {% extends "project_base.html" %}
 {% load custom_markup %}
 
-{% block title %}Sponsorship Period Deleted - {{ block.super }}{% endblock %}
+{% block title %}Sustaining Membership Period Deleted - {{ block.super }}{% endblock %}
 
 {% block extra_head %}
 {% endblock %}
 
 {% block page_title %}
-  <h1>Sponsorship Period Deleted</h1>
+  <h1>Sustaining Membership Period Deleted</h1>
 {% endblock page_title %}
 
 {% block content %}
   <form action="" id="delete-confirmation" method="post">{% csrf_token %}
     <div class="alert row">
       <div class="col-lg-10">
-        <p class="lead">Please confirm you wish to delete the sponsorship period below!</p>
+        <p class="lead">Please confirm you wish to delete the Sustaining Membership period below!</p>
       </div>
       <div class="col-lg-2">
         <div class="btn-group pull-right">
@@ -34,7 +34,7 @@
     </div>
     <div class="row">
       <div class="col-lg-12">
-        <h3>Sponsorship Period: {{ sponsorshipperiod.sponsor.name }} | {{ sponsorshipperiod.sponsor }}, {{ sponsorshipperiod.start_date }}, {{ sponsorshipperiod.end_date }}</h3>
+        <h3>Sustaining Membership Period: {{ sponsorshipperiod.sponsor.name }} | {{ sponsorshipperiod.sponsor }}, {{ sponsorshipperiod.start_date }}, {{ sponsorshipperiod.end_date }}</h3>
       </div>
     </div>
   </form>

--- a/django_project/changes/templates/sponsorship_period/detail.html
+++ b/django_project/changes/templates/sponsorship_period/detail.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block page_title %}
-  <h1>Sponsor Periods (all)</h1>
+  <h1>Sustaining Member Periods (all)</h1>
 {% endblock page_title %}
 
 {% block content %}
@@ -33,7 +33,7 @@
   </div>
   <div class="row">
     <div class="col-lg-8">
-          Sponsorship Level : {{ sponsorshipperiod.sponsorship_level }}<br/>
+          Sustaining Membership Level : {{ sponsorshipperiod.sponsorship_level }}<br/>
           Start Date : {{ sponsorshipperiod.start_date }}<br/>
           End Date : {{ sponsorshipperiod.end_date }}<br/>
           Amount Paid :

--- a/django_project/changes/templates/sponsorship_period/list.html
+++ b/django_project/changes/templates/sponsorship_period/list.html
@@ -1,20 +1,20 @@
 {% extends "project_base.html" %}
 {% load thumbnail %}
 {% load custom_markup %}
-{% block title %}Sponsorship Periods - {{ block.super }}{% endblock %}
+{% block title %}Sustaining Membership Periods - {{ block.super }}{% endblock %}
 
 {% block extra_head %}
 {% endblock %}
 
 {% block page_title %}
-    <h1>Sponsorship Periods (all)</h1>
+    <h1>Sustaining Membership Periods (all)</h1>
 {% endblock page_title %}
 
 {% block content %}
     <div class="page-header">
         <h1 class="text-muted">
             {% if unapproved %}Unapproved {% endif %}
-            Sponsorship Periods
+            Sustaining Membership Periods
             {% if user.is_authenticated %}
                 <div class="pull-right btn-group">
                     {% if user.is_staff or user == project.owner or user in project.changelog_managers.all %}
@@ -38,9 +38,9 @@
     </div>
     {% ifequal num_sponsorshipperiods 0 %}
         {% if unapproved %}
-            <h3>All sponsorship period are approved.</h3>
+            <h3>All sustaining membership period are approved.</h3>
         {% else %}
-            <h3>No sponsorship period are defined, but you can <a
+            <h3>No sustaining membership period are defined, but you can <a
                     class="btn btn-default btn-mini"
                     href='{% url "sponsorshipperiod-create" project_slug %}'>create one</a>.</h3>
         {% endif %}
@@ -58,8 +58,8 @@
                     <tr>
                         <th>Logo</th>
                         <th>Organisation</th>
-                        <th>Amount Sponsored</th>
-                        <th>Sponsorship Period</th>
+                        <th>Amount Contributed</th>
+                        <th>Sustaining Membership Period</th>
                         <th>View</th>
                     </tr>
                 {% endifchanged %}

--- a/django_project/changes/templates/sponsorship_period/update.html
+++ b/django_project/changes/templates/sponsorship_period/update.html
@@ -20,7 +20,7 @@
 
 
 {% block page_title %}
-<h1>Add sponsor periods</h1>
+<h1>Add sustaining member periods</h1>
 {% endblock page_title %}
 
 {% block content %}

--- a/django_project/core/base_templates/includes/base-auth-nav-left.html
+++ b/django_project/core/base_templates/includes/base-auth-nav-left.html
@@ -136,15 +136,15 @@
     <ul class="nav navbar-nav">
         <li>
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                Sponsors <b class="caret"></b>
+                Sustaining Members <b class="caret"></b>
             </a>
             <ul class="dropdown-menu">
-                <li><a href="{% url 'sponsor-list' the_project.slug %}">Sponsors</a></li>
+                <li><a href="{% url 'sponsor-list' the_project.slug %}">Sustaining Members</a></li>
                 {% if user.is_authenticated %}
-                    <li><a href="{% url 'sponsorshiplevel-list' the_project.slug %}">Sponsor Levels</a></li>
-                    <li><a href="{% url 'sponsorshipperiod-list' the_project.slug %}">Sponsor Periods</a></li>
+                    <li><a href="{% url 'sponsorshiplevel-list' the_project.slug %}">Sustaining Member Levels</a></li>
+                    <li><a href="{% url 'sponsorshipperiod-list' the_project.slug %}">Sustaining Member Periods</a></li>
                 {% endif %}
-                <li><a href="{% url 'sponsor-world-map' the_project.slug %}">Sponsors Map</a></li>
+                <li><a href="{% url 'sponsor-world-map' the_project.slug %}">Sustaining Members Map</a></li>
             </ul>
         </li>
     </ul>


### PR DESCRIPTION
fix #1044 

Some wording change:
- [x] Sponsor -> Sustaining Member
- [x] Sponsorship -> Sustaining Membership
- [x] Sponsored (verb) -> Contributed

The sponsorship levels names were changed from the admin section.

![Screenshot from 2019-09-26 11-21-03](https://user-images.githubusercontent.com/26101337/65658144-a9a9e500-e050-11e9-89c6-2064e935589b.png)
![Screenshot from 2019-09-26 11-21-20](https://user-images.githubusercontent.com/26101337/65658146-aadb1200-e050-11e9-91bd-a1d0261eebe1.png)
![Screenshot from 2019-09-26 11-24-18](https://user-images.githubusercontent.com/26101337/65658149-ac0c3f00-e050-11e9-80c2-9f2f434b3226.png)
![Screenshot from 2019-09-26 11-24-30](https://user-images.githubusercontent.com/26101337/65658150-aca4d580-e050-11e9-88c8-cb94d55f1bfb.png)
![Screenshot from 2019-09-26 11-24-51](https://user-images.githubusercontent.com/26101337/65658151-add60280-e050-11e9-9cbf-119ce7cba204.png)
![screencapture-0-0-0-0-61202-en-qgis-sponsors-world-map-2019-09-26-11_20_45](https://user-images.githubusercontent.com/26101337/65658173-c0e8d280-e050-11e9-809d-523c2378ec53.png)
