### PR TITLE
add pillow 5.3.0 in requirements

### DIFF
--- a/deployment/docker/REQUIREMENTS.txt
+++ b/deployment/docker/REQUIREMENTS.txt
@@ -30,6 +30,7 @@ pytz
 django-allauth==0.25.2
 # support special characters
 Unidecode==0.4.20
+Pillow==5.3.0
 reportlab==3.4.0
 xhtml2pdf==0.2b1
 django-modeltranslation==0.12.2


### PR DESCRIPTION
fix #1047 and fix #1039 

Using the latest Pillow breaks the code when using reportlab for drawing image.
We need to explicitly install earlier version of Pillow in requirements. In this case `Pillow==5.3.0`