### PR TITLE
fix version numbering for sorting

### DIFF
--- a/django_project/changes/admin.py
+++ b/django_project/changes/admin.py
@@ -36,7 +36,9 @@ class CategoryAdmin(reversion.VersionAdmin):
 
 
 class VersionAdmin(reversion.VersionAdmin):
-    """Verion admin model."""
+    """Version admin model."""
+
+    list_display = ('__unicode__', 'project',)
 
     def queryset(self, request):
         """Ensure we use the correct manager.

--- a/django_project/changes/models/version.py
+++ b/django_project/changes/models/version.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+import re
 from django.core.urlresolvers import reverse
 # from django.utils.text import slugify
 from common.utilities import version_slugify
@@ -76,8 +77,20 @@ class Version(models.Model):
             filtered_words = [t for t in words if t.lower() not in STOP_WORDS]
             new_list = ' '.join(filtered_words)
             self.slug = version_slugify(new_list)[:50]
-        self.padded_version = self.pad_name(self.name)
+        self.padded_version = self.pad_name(str(self.get_numerical_name()))
         super(Version, self).save(*args, **kwargs)
+
+    def get_numerical_name(self):
+        name = self.name
+        non_decimal = re.compile(r'[^\d.]+')
+        numeric_name = non_decimal.sub('', name)
+        number = numeric_name.split('.')
+
+        # Fix the numbering of the version name to have format: 0.0.0.
+        while len(number) < 3:
+            numeric_name += '.0'
+            number = numeric_name.split('.')
+        return numeric_name
 
     def pad_name(self, version):
         """Create a 0 padded version of the version name.

--- a/django_project/changes/views/version.py
+++ b/django_project/changes/views/version.py
@@ -122,7 +122,7 @@ class VersionListView(VersionMixin, PaginationMixin, ListView):
 
         # fix padded version if there is padded name with alphabet.
         for version in versions_qs:
-            is_alphabet = re.search('[a-zA-Z]', str(version.padded_version))
+            is_alphabet = re.search('[a-zA-Z,.]', str(version.padded_version))
             if is_alphabet is not None:
                 version.save()
 

--- a/django_project/changes/views/version.py
+++ b/django_project/changes/views/version.py
@@ -120,6 +120,12 @@ class VersionListView(VersionMixin, PaginationMixin, ListView):
         """
         versions_qs = Version.objects.all()
 
+        # fix padded version if there is padded name with alphabet.
+        for version in versions_qs:
+            is_alphabet = re.search('[a-zA-Z]', str(version.padded_version))
+            if is_alphabet is not None:
+                version.save()
+
         project_slug = self.kwargs.get('project_slug', None)
         if project_slug:
             try:
@@ -133,8 +139,6 @@ class VersionListView(VersionMixin, PaginationMixin, ListView):
             return versions_qs
         else:
             raise Http404('Sorry! We could not find your version!')
-        # In case no project filter applied
-        return versions_qs
 
 
 class VersionDetailView(VersionMixin, DetailView):


### PR DESCRIPTION
fix #1066 

This PR fixes the sorting on version list by fixing the numbering format of the version which will be used to compute the padded version. 

![Screenshot from 2019-11-18 21-36-11](https://user-images.githubusercontent.com/26101337/69061439-aaa53480-0a4b-11ea-8a29-2a2eb604bce7.png)
![Screenshot from 2019-11-18 21-36-24](https://user-images.githubusercontent.com/26101337/69061444-abd66180-0a4b-11ea-8f36-0290df23deef.png)

