### PR TITLE
fix lesson numbering

### DIFF
--- a/django_project/lesson/templates/section/includes/row-worksheet.html
+++ b/django_project/lesson/templates/section/includes/row-worksheet.html
@@ -2,10 +2,10 @@
 {% load lesson_tags %}
 <div class="row section-list" style="margin-top:5px; margin-left: 20px;">
     <div class="col-lg-9" id="{{ worksheet.module }}">
-        <input class="worksheet-checkbox {{ worksheet.section.slug }}-checkbox" worksheet-pk="{{ worksheet.pk }}" worksheet-number="{{ forloop.parentloop.counter }}.{{ forloop.counter }}" type="checkbox" hidden>
+        <input class="worksheet-checkbox {{ worksheet.section.slug }}-checkbox" worksheet-pk="{{ worksheet.pk }}" worksheet-number="{{ forloop.parentloop.counter|add:page_obj.start_index|add:'-1' }}.{{ forloop.counter }}" type="checkbox" hidden>
         <h4>
-            <a href="{% url "worksheet-detail" project_slug=worksheet.section.project.slug section_slug=worksheet.section.slug pk=worksheet.pk %}?q={{ forloop.parentloop.counter }}.{{ forloop.counter }}">
-                {{ forloop.parentloop.counter }}.{{ forloop.counter }}. {{ worksheet.module }}
+            <a href="{% url "worksheet-detail" project_slug=worksheet.section.project.slug section_slug=worksheet.section.slug pk=worksheet.pk %}?q={{ forloop.parentloop.counter|add:page_obj.start_index|add:'-1' }}.{{ forloop.counter }}">
+                {{ forloop.parentloop.counter|add:page_obj.start_index|add:'-1' }}.{{ forloop.counter }}. {{ worksheet.module }}
             </a>
             {{ worksheet|is_translation_up_to_date }}
         </h4>
@@ -14,12 +14,12 @@
     <div class="col-lg-3">
         <div class="btn-group pull-right">
             <a id="download-pdf-button" class="btn btn-default btn-mini tooltip-toggle" target="_blank"
-               href='{% url "worksheet-zip" project_slug=worksheet.section.project.slug section_slug=worksheet.section.slug pk=worksheet.pk %}?q={{ forloop.parentloop.counter }}.{{ forloop.counter }}'
+               href='{% url "worksheet-zip" project_slug=worksheet.section.project.slug section_slug=worksheet.section.slug pk=worksheet.pk %}?q={{ forloop.parentloop.counter|add:page_obj.start_index|add:'-1' }}.{{ forloop.counter }}'
                data-title="Download {{ worksheet.module }} module and its sample data as ZIP">
                 <span class="fa fa-download"></span>
             </a>
             <a id="download-pdf-button" class="btn btn-default btn-mini tooltip-toggle" target="_blank"
-               href='{% url "worksheet-print" project_slug=worksheet.section.project.slug section_slug=worksheet.section.slug pk=worksheet.pk %}?q={{ forloop.parentloop.counter }}.{{ forloop.counter }}'
+               href='{% url "worksheet-print" project_slug=worksheet.section.project.slug section_slug=worksheet.section.slug pk=worksheet.pk %}?q={{ forloop.parentloop.counter|add:page_obj.start_index|add:'-1' }}.{{ forloop.counter }}'
                data-title="Download {{ worksheet.module }} as PDF">
                 <span class="glyphicon glyphicon-download"></span>
             </a>

--- a/django_project/lesson/templates/section/includes/section-list-detail.html
+++ b/django_project/lesson/templates/section/includes/section-list-detail.html
@@ -5,7 +5,7 @@
     <div class="col-lg-9" id="{{ section.slug }}">
         <input class="section-checkbox" type="checkbox" onchange="toggleCheckAllWorksheet(this)" hidden>
         <h3>
-            {{ forloop.counter }}. {{ section.name }} {{ section|is_translation_up_to_date }}
+            {{ forloop.counter|add:page_obj.start_index|add:'-1' }}. {{ section.name }} {{ section|is_translation_up_to_date }}
         </h3>
          {{ section.notes | base_markdown }}
     </div>


### PR DESCRIPTION
fix #1076 

@timlinux @Gustry 

This PR:
- [x] Fix numbering for lesson list.
![Peek 2019-11-18 18-35](https://user-images.githubusercontent.com/26101337/69049684-0616f880-0a33-11ea-9207-5faadc59cf29.gif)
- [x] Fix the zip file naming so that it will include the downloaded module number e.g. `QGIS-worksheet module 11.1.zip` or `QGIS-worksheet module 3.1 to 3.12.zip`
