### PR TITLE
allow certifying organisation owner to edit and delete its own pending organisation

### DIFF
--- a/django_project/certification/templates/certifying_organisation/pending-list.html
+++ b/django_project/certification/templates/certifying_organisation/pending-list.html
@@ -132,6 +132,8 @@
                             data-title="Reject {{ certifyingorganisation.name }}">
                             <span class="glyphicon glyphicon-thumbs-down"></span>
                         </a>
+                    {% endif %}
+                    {% if not certifyingorganisation.approved and user.is_staff or user == project.owner or user in certifyingorganisation.project.certification_managers.all or user in certifyingorganisation.organisation_owners.all %}
                         <a class="btn btn-default btn-mini tooltip-toggle"
                             href='{% url "certifyingorganisation-update" project_slug=certifyingorganisation.project.slug slug=certifyingorganisation.slug %}'
                             data-title="Edit {{ certifyingorganisation.name }}">


### PR DESCRIPTION
fix #1079 

View for certifying organisation owner but not a staff or managers.
![Screenshot from 2019-11-18 19-18-56](https://user-images.githubusercontent.com/26101337/69052416-8e989780-0a39-11ea-828a-55f000848819.png)
