### PR TITLE
add function to import PR into entries

### DIFF
--- a/django_project/certification/views/certificate.py
+++ b/django_project/certification/views/certificate.py
@@ -419,7 +419,7 @@ def generate_pdf(
         margin_left, (margin_bottom - 20),
         'You can verify this certificate by visiting '
         'http://{}/en/{}/certificate/{}/.'
-            .format(current_site, project.slug, certificate.certificateID))
+        ''.format(current_site, project.slug, certificate.certificateID))
 
     # Close the PDF object cleanly.
     page.showPage()
@@ -626,7 +626,7 @@ def email_all_attendees(request, **kwargs):
                 '{organisation_slug}/course/'
                 '{course_slug}/print/{pk}/\n\n'
                 'Sincerely,\n{convener_firstname} {convener_lastname}'
-                    .format(**data),
+                ''.format(**data),
                 course.course_convener.user.email,
                 [attendee.email],
                 fail_silently=False,

--- a/django_project/changes/admin.py
+++ b/django_project/changes/admin.py
@@ -55,6 +55,12 @@ class VersionAdmin(reversion.admin.VersionAdmin):
 class EntryAdmin(reversion.admin.VersionAdmin):
     """Entry admin model."""
 
+    list_display = ['pk', 'version_name', 'category', 'title']
+    list_filter = ['category']
+
+    def version_name(self, obj):
+        return obj.version.name
+
     def queryset(self, request):
         """Ensure we use the correct manager.
 

--- a/django_project/changes/models/sponsorship_period.py
+++ b/django_project/changes/models/sponsorship_period.py
@@ -61,7 +61,8 @@ class SponsorshipPeriod(models.Model):
     )
 
     currency = models.CharField(
-        help_text=_('The currency that is used for sustaining membership payment.'),
+        help_text=_('The currency that is used for '
+                    'sustaining membership payment.'),
         max_length=50,
         null=True,
         blank=True,

--- a/django_project/changes/templates/version/detail.html
+++ b/django_project/changes/templates/version/detail.html
@@ -58,6 +58,11 @@
             </div>
             <div class="pull-right">
                 {% if user.is_authenticated %}
+                    <button class="btn btn-default tooltip-toggle"
+                            data-title="Import PR from Github into Entries"
+                            data-toggle="modal" data-target="#GithubPRModal">
+                        <i class="fa fa-github"></i>
+                    </button>
                     <a href="{% url 'entry-create' project_slug=version.project.slug version_slug=version.slug %}"
                        class="btn btn-default tooltip-toggle"
                        data-title="Add New Entry">
@@ -74,6 +79,7 @@
     </div>
 
     {% include "version/detail-content.html" %}
+    {% include "version/includes/github-form-modal.html" %}
 {#    we disable disqus temporarily because of unwanted ads. #}
 {#    <h5 id="comments">Comments</h5>#}
 {#    {% disqus_show_comments %}#}

--- a/django_project/changes/templates/version/includes/github-form-modal.html
+++ b/django_project/changes/templates/version/includes/github-form-modal.html
@@ -49,11 +49,11 @@
                 <label>State</label><br>
                 <label style="font-size: 12px; font-weight: normal" class="text-muted">Please select the state of the PRs which you'd like to fetch, no selection means all PRs will be fetched.</label><br>
                 <span class="label-checkbox-github">
-                    <input type="checkbox" class="github-state-option" name="open" value="open">&nbsp;
+                    <input type="checkbox" class="github-state-option" id="open" name="open" value="open">&nbsp;
                     <label for="open">Open</label>
                 </span>
                 <span class="label-checkbox-github">
-                    <input type="checkbox" class="github-state-option" name="closed" value="closed">&nbsp;
+                    <input type="checkbox" class="github-state-option" id="closed" name="closed" value="closed">&nbsp;
                     <label for="closed">Closed</label>
                 </span>
                 <br>
@@ -105,7 +105,7 @@
                     for(var i=0; i<data.length; i++){
                         var label = data[i];
                         var $div = $('<span class="label-checkbox-github"></span>');
-                        var $input = $('<input type="checkbox" class="github-label-option" name="' + label['name'] + '" value="' + label['name'] + '">'+
+                        var $input = $('<input type="checkbox" class="github-label-option" id="' + label['name'] + '" name="' + label['name'] + '" value="' + label['name'] + '">'+
                             '<label style="margin-left: 3px" for="' + label['name'] + '">' + label['name'] + '</label>');
                         $div.append($input);
                         $parentDiv.append($div)

--- a/django_project/changes/templates/version/includes/github-form-modal.html
+++ b/django_project/changes/templates/version/includes/github-form-modal.html
@@ -1,0 +1,219 @@
+<style>
+    .label-checkbox-github {
+        border: 1px solid lightgrey;
+        border-radius: 3px;
+        margin-right: 5px;
+        padding: 6px 7px 3px 7px;
+        white-space: nowrap;
+        line-height: 23px;
+    }
+    .label-github {
+        max-height: 200px;
+        padding-top: 5px;
+        padding-bottom: 5px;
+        overflow-y: auto;
+    }
+    .error {
+        border: 1px solid red !important;
+    }
+    .error-message {
+        padding: 7px 0;
+        background: rgba(255, 173, 173, 0.7);
+    }
+    .error-notification {
+        display: inline-block;
+        color: red;
+        margin-right: 12px;
+    }
+</style>
+
+<!-- Modal -->
+<div class="modal fade" id="GithubPRModal" tabindex="-1" role="dialog" aria-labelledby="GithubPRModalLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+    <div class="modal-content">
+        <div class="modal-header">
+            <h4 class="modal-title" id="exampleModalLabel">Import PR from Github into Entries</h4>
+            <div class="error-message" style="display: none"></div>
+        </div>
+        <div class="modal-body">
+            <form id="github-entry-import">
+                <label for="repo">Repository url</label>
+                <input class="form-control" name="repo" required>
+                <br>
+                <label>Labels</label><br>
+                <label style="font-size: 12px; font-weight: normal" class="text-muted">Please select the label of the PRs which you'd like to fetch, no label selected means all PRs will be fetched.</label>
+                <label style="font-size: 12px; font-weight: normal" class="text-muted">If you select more than one label, only PRs containing all label selected will be fetched.</label><br>
+                <div class="label-github">
+                </div>
+                <br>
+                <label>State</label><br>
+                <label style="font-size: 12px; font-weight: normal" class="text-muted">Please select the state of the PRs which you'd like to fetch, no selection means all PRs will be fetched.</label><br>
+                <span class="label-checkbox-github">
+                    <input type="checkbox" class="github-state-option" name="open" value="open">&nbsp;
+                    <label for="open">Open</label>
+                </span>
+                <span class="label-checkbox-github">
+                    <input type="checkbox" class="github-state-option" name="closed" value="closed">&nbsp;
+                    <label for="open">Closed</label>
+                </span>
+                <br>
+                <br>
+                <label for="category-github-import">Category</label><br>
+                <label style="font-size: 12px; font-weight: normal" class="text-muted">Please select a category where the new entries will associate to.</label><br>
+                <select class="form-control" name="category-github-import" required>
+                </select>
+            </form>
+        </div>
+        <div class="modal-footer">
+            <div class="error-notification" style="display: none">Import error see message above</div>
+            <button type="button" onclick="resetForm()" class="btn btn-secondary">Cancel</button>
+            <button type="submit" onclick="submitForm(this)" class="btn btn-primary">Import <i id="import-loading" style="font-size: 12pt; display: none" class="fa fa-spinner fa-spin fa-3x fa-fw"></i></button>
+        </div>
+        </div>
+    </div>
+</div>
+
+
+<script>
+    $(document).ready(function () {
+        $.ajax({
+            url: '{% url "fetch-category" project_pk=version.project.pk %}',
+            success: function (data) {
+                var $select = $('[name="category-github-import"]');
+                $select.append('<option value="">Select a Category</option>');
+                for(var i=0; i<data.length; i++){
+                    var $element = $('<option value=' + data[i]["id"] + '>' + data[i]["name"] + '</option>');
+                    $select.append($element)
+                }
+            }
+        });
+
+        var $inputRepo = $('[name=repo]');
+        $inputRepo.change(function () {
+            $('.error-message').html('').hide();
+            $('[name=repo]').removeClass('error');
+            var $parentDiv = $('.label-github');
+            $parentDiv.html('<i style="font-size: 12pt" class="fa fa-spinner fa-spin fa-3x fa-fw"></i>');
+            var repo = this.value;
+            $.ajax({
+                url: '{% url "fetch-labels-github" project_pk=version.project.pk %}',
+                data: {
+                    repo: repo
+                },
+                success: function (data) {
+                    $parentDiv.html('');
+                    for(var i=0; i<data.length; i++){
+                        var label = data[i];
+                        var $div = $('<span class="label-checkbox-github"></span>');
+                        var $input = $('<input type="checkbox" class="github-label-option" name="' + label['name'] + '" value="' + label['name'] + '">'+
+                            '<label style="margin-left: 3px" for="' + label['name'] + '">' + label['name'] + '</label>');
+                        $div.append($input);
+                        $parentDiv.append($div)
+                    }
+                },
+                error: function (err) {
+                    $parentDiv.html('Cannot find label for this repository/repository is invalid');
+                }
+            })
+        });
+
+        $('[name="category-github-import"]').change(function () {
+            $('[name="category-github-import"]').removeClass('error');
+            $('.error-message').html('').hide();
+        });
+
+        {% if version.project.project_repository_url %}
+            $inputRepo.val('{{ version.project.project_repository_url }}').trigger('change');
+        {% endif %}
+
+    });
+
+    function formValidation(repo, category) {
+        if(repo === '' || repo === null){
+            $('[name=repo]').addClass('error');
+            $('.error-message').html('Repository url is empty').show();
+            return false;
+        }else if(category === '' || category === null){
+            $('[name="category-github-import"]').addClass('error');
+            $('.error-message').html('Category is empty').show();
+            return false;
+        }else {
+            return true;
+        }
+    }
+
+    function resetForm() {
+        $('button[type="submit"]').prop('disabled', false);
+        $('#github-entry-import').trigger('reset');
+        $('[name="category-github-import"]').removeClass('error');
+        $('[name=repo]').removeClass('error');
+        $('#form_id').trigger("reset");
+        {% if version.project.project_repository_url %}
+            $('[name=repo]').val('{{ version.project.project_repository_url }}').trigger('change');
+        {% endif %}
+        $('.error-notification').hide();
+        $('#GithubPRModal').modal('hide');
+    }
+
+    function submitForm(obj) {
+        $('.error-notification').hide();
+        var repo = $('[name="repo"]').val();
+        var labels = [];
+        $('.github-label-option:checked').each(function () {
+            labels.push($(this).val())
+        });
+        var states = [];
+        $('.github-state-option:checked').each(function () {
+            states.push($(this).val())
+        });
+
+        var query = '';
+        if(labels.length > 0){
+            for(var i in labels){
+                query += 'label:"' + labels[i] + '"+'
+            }
+        }
+
+        if(states.length === 1){
+            for(var i in states){
+                query += 'state:' + states[i]
+            }
+        }
+        var category = $('[name="category-github-import"]').find(":selected").val();
+
+        var valid = formValidation(repo, category);
+
+        if(valid) {
+            var $button = $(obj).closest('button');
+            $button.prop('disabled', true);
+            $('#import-loading').show();
+
+            $.ajax({
+                url: '{% url "fetch-pr-github" project_pk=version.project.pk %}',
+                type: 'POST',
+                data: {
+                    'repo': repo,
+                    'query': query,
+                    'category': category,
+                    'version_slug': '{{ version.slug }}'
+                },
+                dataType: 'json',
+                success: function (data) {
+                    if(data['status'] === 'success') {
+                        location.reload()
+                    } else {
+                        $('.error-message').html(data['reason']).show();
+                        $button.prop('disabled', false);
+                        $('#import-loading').hide();
+                        $('.error-notification').show();
+                    }
+                },
+                error: function (err) {
+                    console.log(err);
+                    $button.prop('disabled', false);
+                    $('#import-loading').hide();
+                }
+            });
+        }
+    }
+</script>

--- a/django_project/changes/templates/version/includes/github-form-modal.html
+++ b/django_project/changes/templates/version/includes/github-form-modal.html
@@ -54,7 +54,7 @@
                 </span>
                 <span class="label-checkbox-github">
                     <input type="checkbox" class="github-state-option" name="closed" value="closed">&nbsp;
-                    <label for="open">Closed</label>
+                    <label for="closed">Closed</label>
                 </span>
                 <br>
                 <br>
@@ -176,7 +176,7 @@
 
         if(states.length === 1){
             for(var i in states){
-                query += 'state:' + states[i]
+                query += 'state:' + states[i] + '+'
             }
         }
         var category = $('[name="category-github-import"]').find(":selected").val();

--- a/django_project/changes/urls.py
+++ b/django_project/changes/urls.py
@@ -87,6 +87,9 @@ from .views import (
     ApproveSponsorshipPeriodView,
 
     generate_sponsor_cloud,
+    FetchGithubPRs,
+    FetchRepoLabels,
+    FetchCategory
 )
 from changes.views.sustaining_member import (
     SustainingMemberCreateView
@@ -122,6 +125,15 @@ urlpatterns = [
         name='category-update'),
 
     # Version management
+    url(regex='^(?P<project_pk>[\w-]+)/version/fetch-github-pr/$',
+        view=FetchGithubPRs.as_view(),
+        name='fetch-pr-github'),
+    url(regex='^(?P<project_pk>[\w-]+)/version/fetch-github-label/$',
+        view=FetchRepoLabels.as_view(),
+        name='fetch-labels-github'),
+    url(regex='^(?P<project_pk>[\w-]+)/version/fetch-category/$',
+        view=FetchCategory.as_view(),
+        name='fetch-category'),
     url(regex='^(?P<project_slug>[\w-]+)/version/list/$',
         view=VersionListView.as_view(),
         name='version-list'),

--- a/django_project/changes/views/__init__.py
+++ b/django_project/changes/views/__init__.py
@@ -6,3 +6,4 @@ from changes.views.sponsor import *
 from changes.views.sponsorship_level import *
 from changes.views.sponsorship_period import *
 from changes.views.sustaining_member import *
+from changes.views.changelog_github import *

--- a/django_project/changes/views/changelog_github.py
+++ b/django_project/changes/views/changelog_github.py
@@ -1,0 +1,176 @@
+# coding=utf-8
+import requests
+from braces.views import LoginRequiredMixin
+from rest_framework import serializers
+from rest_framework.views import APIView, Response
+from core.settings.secret import GIT_TOKEN
+from base.models.project import Project
+from changes.models.category import Category
+from changes.models.entry import Entry
+from changes.models.version import Version
+
+
+def create_entry_from_github_pr(version, category, data, user):
+    """Function to create entry objects from github PR.
+
+    :return:
+    """
+
+    for item in data:
+        response = requests.get(
+            item['user']['url'],
+            headers={'Authorization': 'token {}'.format(GIT_TOKEN)})
+
+        name = ''
+        if response.status_code == 200:
+            name = response.json()['name']
+            if not name:
+                name = response.json()['login']
+
+        entry = Entry.objects.create(
+            category=category,
+            title=item['title'],
+            description=item['body'],
+            developer_url=item['user']['url'],
+            developed_by=name,
+            author=user,
+            version=version
+        )
+    return True
+
+
+class FetchGithubPRs(APIView):
+    """
+    API to fetch PRs from Github repository.
+    """
+
+    def post(self, request, project_pk):
+        user = request.user
+        repo = request.POST.get('repo', None)
+        category_pk = request.POST.get('category', None)
+        version_slug = request.POST.get('version_slug', None)
+
+        if not repo or not category_pk or not version_slug:
+            return Response({
+                'status': 'failed',
+                'reason': 'Repository or category or version'
+                          ' parameter is not found.'
+            })
+
+        try:
+            project = Project.objects.get(pk=project_pk)
+        except Project.DoesNotExist:
+            return Response({
+                'status': 'failed',
+                'reason': 'This project is not found.'
+            })
+
+        try:
+            category = Category.objects.get(pk=category_pk, project=project)
+        except Category.DoesNotExist:
+            return Response({
+                'status': 'failed',
+                'reason': 'This category is not found.'
+            })
+
+        try:
+            version = Version.objects.get(slug=version_slug, project=project)
+        except Version.DoesNotExist:
+            return Response({
+                'status': 'failed',
+                'reason': 'This version is not found.'
+            })
+
+        results = []
+
+        repo = repo.replace('https://github.com/', '')
+        query = request.POST.get('query', None)
+
+        url = 'https://api.github.com/search/issues?' \
+              'q=is:pr+repo:{}+{}&per_page=100'.format(repo, query)
+
+        response = requests.get(
+            url,
+            headers={'Authorization': 'token {}'.format(GIT_TOKEN)})
+
+        try:
+            results.extend(response.json()['items'])
+        except:
+            return Response([])
+
+        header_link = response.links
+        if header_link:
+            while 'next' in response.links.keys():
+                next_url = response.links['next']['url']
+                response = requests.get(
+                    next_url,
+                    headers={
+                        'Authorization': 'token {}'.format(GIT_TOKEN)})
+                try:
+                    results.extend(response.json()['items'])
+                except:
+                    pass
+
+        create_entry_from_github_pr(version, category, results, user)
+        return Response({
+            'status': 'success',
+            'reason': ''
+        })
+
+
+class FetchRepoLabels(LoginRequiredMixin, APIView):
+    """
+    API to fetch list of labels on the repo.
+    """
+
+    def get(self, request, project_pk):
+        repo = request.GET.get('repo')
+
+        if not repo:
+            return Response([])
+
+        results = []
+        repo = repo.replace('https://github.com/', '')
+        url = 'https://api.github.com/repos/{}/labels?per_page=100'.format(
+            repo)
+        response = requests.get(
+            url, headers={'Authorization': 'token {}'.format(GIT_TOKEN)})
+        if response.status_code == 200:
+            results.extend(response.json())
+
+        header_link = response.links
+        if header_link:
+            while 'next' in response.links.keys():
+                next_url = response.links['next']['url']
+                response = requests.get(
+                    next_url,
+                    headers={
+                        'Authorization': 'token {}'.format(GIT_TOKEN)})
+                try:
+                    results.extend(response.json())
+                except:
+                    pass
+        return Response(results)
+
+
+class CategorySerializer(serializers.ModelSerializer):
+    """Category model serializer."""
+
+    class Meta:
+        model = Category
+        fields = ['id', 'name']
+
+
+class FetchCategory(LoginRequiredMixin, APIView):
+    """
+    API to fetch Category.
+    """
+
+    def get(self, request, project_pk):
+        try:
+            project = Project.objects.get(pk=project_pk)
+            categories = Category.objects.filter(project=project)
+            serializer = CategorySerializer(categories, many=True)
+            return Response(serializer.data)
+        except:
+            return Response([])

--- a/django_project/changes/views/changelog_github.py
+++ b/django_project/changes/views/changelog_github.py
@@ -27,7 +27,8 @@ def create_entry_from_github_pr(version, category, data, user):
             if not name:
                 name = response.json()['login']
 
-        entry = Entry.objects.create(  #noqa
+        # Create new entry from data.
+        Entry.objects.create(
             category=category,
             title=item['title'],
             description=item['body'],

--- a/django_project/changes/views/changelog_github.py
+++ b/django_project/changes/views/changelog_github.py
@@ -3,11 +3,15 @@ import requests
 from braces.views import LoginRequiredMixin
 from rest_framework import serializers
 from rest_framework.views import APIView, Response
-from core.settings.secret import GIT_TOKEN
 from base.models.project import Project
 from changes.models.category import Category
 from changes.models.entry import Entry
 from changes.models.version import Version
+
+try:
+    from core.settings.secret import GIT_TOKEN
+except ImportError:
+    GIT_TOKEN = ''
 
 
 def create_entry_from_github_pr(version, category, data, user):

--- a/django_project/changes/views/changelog_github.py
+++ b/django_project/changes/views/changelog_github.py
@@ -27,7 +27,7 @@ def create_entry_from_github_pr(version, category, data, user):
             if not name:
                 name = response.json()['login']
 
-        entry = Entry.objects.create(
+        entry = Entry.objects.create(  #noqa
             category=category,
             title=item['title'],
             description=item['body'],

--- a/django_project/core/settings/contrib.py
+++ b/django_project/core/settings/contrib.py
@@ -131,7 +131,7 @@ ACCOUNT_AUTHENTICATION_METHOD = 'username_email'
 
 # Stripe keys
 STRIPE_LIVE_PUBLIC_KEY = os.environ.get("STRIPE_LIVE_PUBLIC_KEY", "")
-STRIPE_LIVE_SECRET_KEY = os.environ.get("STRIPE_LIVE_SECRET_KEY", "live")
+STRIPE_LIVE_SECRET_KEY = os.environ.get("STRIPE_LIVE_SECRET_KEY", "sk_live_")
 STRIPE_TEST_PUBLIC_KEY = os.environ.get("STRIPE_TEST_PUBLIC_KEY", "")
 STRIPE_TEST_SECRET_KEY = os.environ.get("STRIPE_TEST_SECRET_KEY", "sk_test_")
 STRIPE_LIVE_MODE = False  # Change to True in production


### PR DESCRIPTION
fix #1128 

This PR:
- [x] Added function to fetched PRs from github
- [x] Added modal in version detail view to import PRs from github
- [x] Added form validation

Note:
- On deployment we need github token so that we can have request to github API up until 5000 request per hour, without this token we only have 60 requests per hour 
- for rate limiting, see: https://developer.github.com/v3/#rate-limiting.
- to set up github token see: https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line#creating-a-token

![Peek 2020-02-11 12-06](https://user-images.githubusercontent.com/26101337/74212568-5ebf0000-4cc7-11ea-8025-d4a252397c55.gif)

## How to use
1. Click on the github icon on the right side of the page, it will open a pop up to import the PRs.
2. The repository url is filled automatically but should you like to import the PR from another repository you can fill it here too (<b>required</b>).
3. Wait until the label options is rendered.
4. Select the label of which you want to import the PR, if you select more than one label it will only fetch the PR containing all of the selected labels.
5. Select the state of the PR, it can be open or closed or both, if you don't select any it will fetch all PR regardless open or closed.
6. Select a category where the new entries will be associated to (**required**).
7. Click import, it will begin fetching your PRs and rendering them into entries.