### PR TITLE
change font to support turkish characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,4 +181,7 @@ Thank you to the individual contributors who have helped to build projecta:
 * Ismail Sunni : imajimatika@gmail.com
 * Richard Duivenvoorde : richard@duif.net
 * Rischan Mafrur
+* Etienne Trimaille
+* Anita Hapsari
+* Muhammad Yarjuna Rohmat
 

--- a/django_project/certification/views/certificate.py
+++ b/django_project/certification/views/certificate.py
@@ -242,7 +242,7 @@ def generate_pdf(
             font_folder, 'Times New Roman 400.ttf')
         pdfmetrics.registerFont(TTFont('Noto-Bold', bold_ttf_file))
         pdfmetrics.registerFont(TTFont('Noto-Regular', regular_ttf_file))
-    except TTFError:
+    except (TTFError, KeyError):
         pass
 
     page = canvas.Canvas(pathname, pagesize=landscape(A4))

--- a/django_project/certification/views/certificate.py
+++ b/django_project/certification/views/certificate.py
@@ -380,7 +380,7 @@ def generate_pdf(
             width=100, height=70, preserveAspectRatio=True, anchor='s',
             mask='auto')
 
-    page.setFont('Times-Italic', 12)
+    page.setFont('Noto-Regular', 12)
     if project.project_representative:
         page.drawCentredString(
             (margin_left + 150), (margin_bottom + 60),


### PR DESCRIPTION
fix #1043 

"Times-Italic" font does not support turkish characters, so I changed it to use the regular one, "Noto-Regular" is it okay @timlinux ?

before:
![Screenshot from 2020-02-17 21-31-30](https://user-images.githubusercontent.com/26101337/74663086-b8df2a00-51cd-11ea-8d9c-d5c7011cf6aa.png)

after:
![Screenshot from 2020-02-17 21-31-39](https://user-images.githubusercontent.com/26101337/74663097-baa8ed80-51cd-11ea-870e-b2c1811e7a4e.png)
