### PR TITLE
add feed for training center and courses

### DIFF
--- a/django_project/certification/feeds/__init__.py
+++ b/django_project/certification/feeds/__init__.py
@@ -1,0 +1,1 @@
+# coding=utf-8

--- a/django_project/certification/feeds/course.py
+++ b/django_project/certification/feeds/course.py
@@ -63,7 +63,7 @@ class UpcomingCourseFeed(Feed):
          :returns: Title of the RSS Feed.
          :rtype: str
          """
-        return 'JSON Feed upcoming course of {}'.format(obj.name)
+        return 'JSON Feed for upcoming course of {}'.format(obj.name)
 
     def link(self, obj):
         """Return the url of the certifying organisation.
@@ -98,7 +98,7 @@ class UpcomingCourseFeed(Feed):
          :returns: Description of the RSS Feed.
          :rtype: str
          """
-        return 'These are the upcoming course ' \
+        return 'These are the upcoming courses ' \
                'of {}.'.format(obj.name)
 
     def items(self, obj):
@@ -162,6 +162,29 @@ class UpcomingCourseFeed(Feed):
 
 class PastCourseFeed(UpcomingCourseFeed):
     """Feed for past courses."""
+
+    def title(self, obj):
+        """Return a title for the RSS.
+
+         :param obj: A certifying organisation
+         :type obj: CertifyingOrganisation
+
+         :returns: Title of the RSS Feed.
+         :rtype: str
+         """
+        return 'JSON Feed for past course of {}'.format(obj.name)
+
+    def description(self, obj):
+        """Return a description for the RSS.
+
+         :param obj: A certifying organisation
+         :type obj: CertifyingOrganisation
+
+         :returns: Description of the RSS Feed.
+         :rtype: str
+         """
+        return 'These are the past courses ' \
+               'of {}.'.format(obj.name)
 
     def items(self, obj):
         """Return upcoming course of the certifying organisation.

--- a/django_project/certification/feeds/course.py
+++ b/django_project/certification/feeds/course.py
@@ -141,16 +141,20 @@ class UpcomingCourseFeed(Feed):
         return item.link
 
     def item_extra_kwargs(self, item):
+        if item.course_convener.degree:
+            degree = ', {}'.format(item.course_convener.degree)
+        else:
+            degree = ''
         return {
             'start_date': item.start_date,
             'end_date': item.end_date,
             'trained_competence': item.trained_competence,
             'language': item.language,
             'course_type': item.course_type.name,
-            'course_convener': '{} {} {}'.format(
+            'course_convener': '{} {}{}'.format(
                 item.course_convener.user.first_name,
                 item.course_convener.user.last_name,
-                item.course_convener.degree
+                degree
             ),
             'training_center': item.training_center,
         }

--- a/django_project/certification/feeds/course.py
+++ b/django_project/certification/feeds/course.py
@@ -1,0 +1,177 @@
+# coding=utf-8
+from datetime import datetime
+from django.contrib.gis.feeds import Feed
+from django.http import Http404
+from django.shortcuts import get_object_or_404
+from .json_feed import CourseJSONFeed
+from base.models.project import Project
+from certification.models.certifying_organisation import CertifyingOrganisation
+from certification.models.course import Course
+
+
+class UpcomingCourseFeed(Feed):
+    """Feed for upcoming courses."""
+
+    feed_type = CourseJSONFeed
+
+    def get_object(self, request, *args, **kwargs):
+        """Return the certifying organisation object that
+        matches the project_slug and organisation slug.
+
+        :param request: The incoming HTTP request object
+        :type request: Request object
+
+        :param args: Positional arguments
+        :type args: tuple
+
+        :param kwargs: Keyword arguments
+        :type kwargs: dict
+
+        :returns: certifying organisation
+        :rtype: CertifyingOrganisation
+
+        :raises: Http404
+        """
+        try:
+            project_slug = kwargs.get('project_slug', None)
+            project = get_object_or_404(Project, slug=project_slug)
+            organisation_slug = kwargs.get('organisation_slug', None)
+            certifying_organisation = (
+                get_object_or_404(
+                    CertifyingOrganisation,
+                    slug=organisation_slug,
+                    project=project
+                ))
+            certifying_organisation.uri = (
+                self.get_absolute_obj_url(request, certifying_organisation))
+            certifying_organisation.request = request
+            return certifying_organisation
+        except Http404:
+            raise Http404(
+                'Sorry! We could not find your '
+                'project/certifying organisation!')
+
+    def get_absolute_obj_url(self, request, obj):
+        return request.build_absolute_uri(obj.get_absolute_url())
+
+    def title(self, obj):
+        """Return a title for the RSS.
+
+         :param obj: A certifying organisation
+         :type obj: CertifyingOrganisation
+
+         :returns: Title of the RSS Feed.
+         :rtype: str
+         """
+        return 'JSON Feed upcoming course of {}'.format(obj.name)
+
+    def link(self, obj):
+        """Return the url of the certifying organisation.
+
+        :param obj: A certifying organisation
+        :type obj: CertifyingOrganisation
+
+        :returns: Url of the certifying organisation.
+        :rtype: str
+        """
+        return obj.uri
+
+    def feed_extra_kwargs(self, obj):
+        """Return the homepage of the certifying organisation.
+
+        :param obj: A certifying organisation
+        :type obj: CertifyingOrganisation
+
+        :returns: Homepage of the certifying organisation.
+        :rtype: str
+        """
+        return {
+            'homepage': obj.url,
+        }
+
+    def description(self, obj):
+        """Return a description for the RSS.
+
+         :param obj: A certifying organisation
+         :type obj: CertifyingOrganisation
+
+         :returns: Description of the RSS Feed.
+         :rtype: str
+         """
+        return 'These are the upcoming course ' \
+               'of {}.'.format(obj.name)
+
+    def items(self, obj):
+        """Return upcoming course of the certifying organisation.
+
+        :param obj: A certifying organisation
+        :type obj: CertifyingOrganisation
+
+        :returns: List of course of a certifying organisation
+        :rtype: list
+        """
+        today = datetime.today()
+        courses = Course.objects.filter(
+            certifying_organisation=obj, start_date__gte=today
+        ).order_by('-start_date')
+        for course in courses:
+            course.link = self.get_absolute_obj_url(obj.request, course)
+        return courses
+
+    def item_title(self, item):
+        """Return the title of the training center.
+
+        :param item: Course object of a certifying organisation
+        :type item: Course
+
+        :returns: name of the course
+        :rtype: str
+        """
+        return item.name
+
+    def item_link(self, item):
+        """Return the title of the training center.
+
+        :param item: Course object of a certifying organisation
+        :type item: Course
+
+        :returns: url of the course
+        :rtype: str
+        """
+        return item.link
+
+    def item_extra_kwargs(self, item):
+        return {
+            'start_date': item.start_date,
+            'end_date': item.end_date,
+            'trained_competence': item.trained_competence,
+            'language': item.language,
+            'course_type': item.course_type.name,
+            'course_convener': '{} {} {}'.format(
+                item.course_convener.user.first_name,
+                item.course_convener.user.last_name,
+                item.course_convener.degree
+            ),
+            'training_center': item.training_center,
+        }
+
+
+class PastCourseFeed(UpcomingCourseFeed):
+    """Feed for past courses."""
+
+    def items(self, obj):
+        """Return upcoming course of the certifying organisation.
+
+        :param obj: A certifying organisation
+        :type obj: CertifyingOrganisation
+
+        :returns: List of course of a certifying organisation
+        :rtype: list
+        """
+        today = datetime.today()
+        courses = Course.objects.filter(
+            certifying_organisation=obj, end_date__lte=today
+        ).order_by('-start_date')
+        for course in courses:
+            course.link = self.get_absolute_obj_url(obj.request, course)
+        return courses

--- a/django_project/certification/feeds/geojson_feed.py
+++ b/django_project/certification/feeds/geojson_feed.py
@@ -1,0 +1,50 @@
+# coding=utf-8
+import json
+from django.utils.feedgenerator import SyndicationFeed, rfc2822_date
+
+
+class GeoJSONFeed(SyndicationFeed):
+    """GeoJSON feed for training centers."""
+
+    content_type = 'application/json; charset=utf-8'
+
+    def write(self, outfile, encoding):
+        data = {
+            'rss': {
+                'version': '2.0',
+                'channel': self.add_root_elements()
+            }
+        }
+
+        if self.items:
+            item_element = []
+            for item in self.items:
+                item_element += [self.add_item_elements(item), ]
+            data['rss']['channel']['item'] = item_element
+        outfile.write(json.dumps(data))
+
+    def add_item_elements(self, item):
+        item_elements = {
+            'type': 'Feature',
+            'geometry': {
+                'type': 'Point',
+                'coordinates': [
+                    round(item['location'].x, 2),
+                    round(item['location'].y, 2)
+                ],
+            },
+            'properties': {
+                'name': item['description']
+            }
+        }
+        return item_elements
+
+    def add_root_elements(self):
+        root_elements = {
+            'title': self.feed['title'],
+            'description': self.feed['description'],
+            'link': self.feed['link'],
+            'homepage': self.feed['homepage'],
+            'lastBuildDate': rfc2822_date(self.latest_post_date())
+        }
+        return root_elements

--- a/django_project/certification/feeds/json_feed.py
+++ b/django_project/certification/feeds/json_feed.py
@@ -31,7 +31,8 @@ class CourseJSONFeed(SyndicationFeed):
             'end_date': str(item['end_date']),
             'course_convener': item['course_convener'],
             'course_type': item['course_type'],
-            'language': item['language']
+            'language': item['language'],
+            'certifying_organisation': item['certifying_organisation'].name
         }
 
         if item['trained_competence']:

--- a/django_project/certification/feeds/json_feed.py
+++ b/django_project/certification/feeds/json_feed.py
@@ -1,0 +1,63 @@
+# coding=utf-8
+import json
+from django.utils.feedgenerator import SyndicationFeed, rfc2822_date
+
+
+class CourseJSONFeed(SyndicationFeed):
+    """JSON feed for course."""
+
+    content_type = 'application/json; charset=utf-8'
+
+    def write(self, outfile, encoding):
+        data = {
+            'rss': {
+                'version': '2.0',
+                'channel': self.add_root_elements()
+            }
+        }
+
+        if self.items:
+            item_element = []
+            for item in self.items:
+                item_element += [self.add_item_elements(item), ]
+            data['rss']['channel']['item'] = item_element
+        outfile.write(json.dumps(data))
+
+    def add_item_elements(self, item):
+        item_elements = {
+            'title': item['title'],
+            'link': item['link'],
+            'start_date': str(item['start_date']),
+            'end_date': str(item['end_date']),
+            'course_convener': item['course_convener'],
+            'course_type': item['course_type'],
+            'language': item['language']
+        }
+
+        if item['trained_competence']:
+            item_elements['trained_competence'] = item['trained_competence']
+
+        if item['training_center']:
+            item_elements['training_center'] = {
+                'type': 'Feature',
+                'geometry': {
+                    'type': 'Point',
+                    'coordinates': [
+                        round(item['training_center'].location.x, 2),
+                        round(item['training_center'].location.y, 2)
+                    ],
+                },
+                'properties': {
+                    'name': item['training_center'].name
+                }
+            }
+        return item_elements
+
+    def add_root_elements(self):
+        root_elements = {
+            'title': self.feed['title'],
+            'description': self.feed['description'],
+            'link': self.feed['link'],
+            'lastBuildDate': rfc2822_date(self.latest_post_date())
+        }
+        return root_elements

--- a/django_project/certification/feeds/training_center.py
+++ b/django_project/certification/feeds/training_center.py
@@ -127,4 +127,3 @@ class TrainingCenterFeed(Feed):
         return {
             'location': item.location
         }
-

--- a/django_project/certification/feeds/training_center.py
+++ b/django_project/certification/feeds/training_center.py
@@ -1,0 +1,130 @@
+# coding=utf-8
+from django.contrib.gis.feeds import Feed
+from django.http import Http404
+from django.shortcuts import get_object_or_404
+from base.models.project import Project
+from certification.models.certifying_organisation import CertifyingOrganisation
+from certification.models.training_center import TrainingCenter
+from .geojson_feed import GeoJSONFeed
+
+
+class TrainingCenterFeed(Feed):
+    """Feed for training center."""
+
+    feed_type = GeoJSONFeed
+
+    def get_object(self, request, *args, **kwargs):
+        """Return the certifying organisation object that
+        matches the project_slug and organisation slug.
+
+        :param request: The incoming HTTP request object
+        :type request: Request object
+
+        :param args: Positional arguments
+        :type args: tuple
+
+        :param kwargs: Keyword arguments
+        :type kwargs: dict
+
+        :returns: certifying organisation
+        :rtype: CertifyingOrganisation
+
+        :raises: Http404
+        """
+        try:
+            project_slug = kwargs.get('project_slug', None)
+            project = get_object_or_404(Project, slug=project_slug)
+            organisation_slug = kwargs.get('organisation_slug', None)
+            certifying_organisation = (
+                get_object_or_404(
+                    CertifyingOrganisation,
+                    slug=organisation_slug,
+                    project=project
+                ))
+            certifying_organisation.uri = (
+                self.get_absolute_obj_url(request, certifying_organisation))
+            return certifying_organisation
+        except Http404:
+            raise Http404(
+                'Sorry! We could not find your '
+                'project/certifying organisation!')
+
+    def get_absolute_obj_url(self, request, obj):
+        return request.build_absolute_uri(obj.get_absolute_url())
+
+    def title(self, obj):
+        """Return a title for the RSS.
+
+         :param obj: A certifying organisation
+         :type obj: CertifyingOrganisation
+
+         :returns: Title of the RSS Feed.
+         :rtype: str
+         """
+        return 'GeoJSON Feed training center of {}'.format(obj.name)
+
+    def link(self, obj):
+        """Return the url of the certifying organisation.
+
+        :param obj: A certifying organisation
+        :type obj: CertifyingOrganisation
+
+        :returns: Url of the certifying organisation.
+        :rtype: str
+        """
+        return obj.uri
+
+    def feed_extra_kwargs(self, obj):
+        """Return the homepage of the certifying organisation.
+
+        :param obj: A certifying organisation
+        :type obj: CertifyingOrganisation
+
+        :returns: Homepage of the certifying organisation.
+        :rtype: str
+        """
+        return {
+            'homepage': obj.url
+        }
+
+    def description(self, obj):
+        """Return a description for the RSS.
+
+         :param obj: A certifying organisation
+         :type obj: CertifyingOrganisation
+
+         :returns: Description of the RSS Feed.
+         :rtype: str
+         """
+        return 'These are the training center ' \
+               'of {}.'.format(obj.name)
+
+    def items(self, obj):
+        """Return training center of the certifying organisation.
+
+        :param obj: A certifying organisation
+        :type obj: CertifyingOrganisation
+
+        :returns: List of training center of a certifying organisation
+        :rtype: list
+        """
+        return TrainingCenter.objects.filter(
+            certifying_organisation=obj,
+        ).order_by('-name')
+
+    def item_title(self, item):
+        """Return the title of the training center.
+
+        :param item: Training center object of a certifying organisation
+        :type item: TrainingCenter
+
+        :returns: name of the training center
+        :rtype: str
+        """
+        return item.name
+
+    def item_extra_kwargs(self, item):
+        return {
+            'location': item.location
+        }
+

--- a/django_project/certification/models/certifying_organisation.py
+++ b/django_project/certification/models/certifying_organisation.py
@@ -207,7 +207,7 @@ class CertifyingOrganisation(models.Model):
         :return: URL
         :rtype: str
         """
-        return reverse('certifying-organisation-detail', kwargs={
+        return reverse('certifyingorganisation-detail', kwargs={
                 'slug': self.slug,
                 'project_slug': self.project.slug
         })

--- a/django_project/certification/models/course.py
+++ b/django_project/certification/models/course.py
@@ -127,5 +127,6 @@ class Course(models.Model):
         """
         return reverse('course-detail', kwargs={
             'slug': self.slug,
-            'certifyingorganisation_slug': self.certifying_organisation.slug
+            'organisation_slug': self.certifying_organisation.slug,
+            'project_slug': self.certifying_organisation.project.slug
         })

--- a/django_project/certification/models/training_center.py
+++ b/django_project/certification/models/training_center.py
@@ -77,7 +77,7 @@ class TrainingCenter(SlugifyingMixin, models.Model):
         :return: URL
         :rtype: str
         """
-        return reverse('training-center-detail', kwargs={
+        return reverse('trainingcenter-detail', kwargs={
             'slug': self.slug,
             'organisation_slug': self.certifying_organisation.slug,
             'project_slug': self.certifying_organisation.project.slug

--- a/django_project/certification/templates/certifying_organisation/detail.html
+++ b/django_project/certification/templates/certifying_organisation/detail.html
@@ -104,12 +104,12 @@
     {% endif %}
 
     <div class="row">
-        <div class="col-lg-10">
+        <div class="col-lg-8">
             <h1>{{ certifyingorganisation.name }}</h1><br/>
         </div>
 
         {# Only organisation owners or staff can edit #}
-        <div class="col-lg-2">
+        <div class="col-lg-4">
 
             <div class="pull-right">
             <a class="glyphicon glyphicon-info-sign tooltip-toggle about-link"
@@ -120,6 +120,21 @@
 
 
             <div class="btn-group">
+                <a class="btn btn-default btn-mini tooltip-toggle rss-icon"
+                       href='{% url "feed-training-center" project_slug=certifyingorganisation.project.slug organisation_slug=certifyingorganisation.slug %}' target="_blank"
+                       data-title="GeoJSON Feed for List of Training Center">
+                        <i class="fa fa-rss-square"></i>
+                    </a>
+                <a class="btn btn-default btn-mini tooltip-toggle rss-icon"
+                       href='{% url "feed-upcoming-course" project_slug=certifyingorganisation.project.slug organisation_slug=certifyingorganisation.slug %}' target="_blank"
+                       data-title="Feed for List of Upcoming Courses">
+                        <i class="fa fa-rss"></i>
+                    </a>
+                <a class="btn btn-default btn-mini tooltip-toggle rss-icon"
+                       href='{% url "feed-past-course" project_slug=certifyingorganisation.project.slug organisation_slug=certifyingorganisation.slug %}' target="_blank"
+                       data-title="Feed for List of Past Courses">
+                        <i class="fa fa-rss" style="color: grey"></i>
+                    </a>
                 {% if user in certifyingorganisation.organisation_owners.all or user.is_staff or user == project.owner or user in certifyingorganisation.project.certification_manager.all %}
                 <a class="btn btn-default btn-mini btn-delete tooltip-toggle"
                    href='{% url "certifyingorganisation-delete" project_slug=certifyingorganisation.project.slug slug=certifyingorganisation.slug %}'

--- a/django_project/certification/templates/certifying_organisation/list.html
+++ b/django_project/certification/templates/certifying_organisation/list.html
@@ -29,6 +29,16 @@
                        data-title="Sign Up for Certification!">
                         Sign Up
                     </a>
+                    <a class="btn btn-default btn-mini tooltip-toggle rss-icon"
+                       href='{% url "feed-upcoming-project-course" project_slug %}' target="_blank"
+                       data-title="Feed for List of All Upcoming Courses">
+                        <i class="fa fa-rss"></i>
+                    </a>
+                    <a class="btn btn-default btn-mini tooltip-toggle rss-icon"
+                           href='{% url "feed-past-project-course" project_slug %}' target="_blank"
+                           data-title="Feed for List of All Past Courses">
+                            <i class="fa fa-rss" style="color: grey"></i>
+                        </a>
                     {% if user.is_staff or user == the_project.owner or user in the_project.certification_managers.all %}
                         <a class="btn btn-default btn-mini tooltip-toggle"
                            href='{% url "certifyingorganisation-create" project_slug %}'

--- a/django_project/certification/urls.py
+++ b/django_project/certification/urls.py
@@ -2,6 +2,8 @@
 """Urls for certification apps."""
 
 from django.conf.urls import url
+from .feeds.training_center import TrainingCenterFeed
+from .feeds.course import UpcomingCourseFeed, PastCourseFeed
 from .views import (
     # Certifying Organisation.
     CertifyingOrganisationCreateView,
@@ -293,4 +295,18 @@ urlpatterns = [
     # API Views
     url(regex='^(?P<project_slug>[\w-]+)/get-status-list/$',
         view=GetStatus.as_view(), name='get-status-list'),
+
+    # Feeds
+    url(regex='^(?P<project_slug>[\w-]+)/certifyingorganisation/'
+              '(?P<organisation_slug>[\w-]+)/feed/training-center/$',
+        view=TrainingCenterFeed(),
+        name='feed-training-center'),
+    url(regex='^(?P<project_slug>[\w-]+)/certifyingorganisation/'
+              '(?P<organisation_slug>[\w-]+)/feed/upcoming-course/$',
+        view=UpcomingCourseFeed(),
+        name='feed-upcoming-course'),
+    url(regex='^(?P<project_slug>[\w-]+)/certifyingorganisation/'
+              '(?P<organisation_slug>[\w-]+)/feed/past-course/$',
+        view=PastCourseFeed(),
+        name='feed-past-course'),
 ]

--- a/django_project/certification/urls.py
+++ b/django_project/certification/urls.py
@@ -3,7 +3,12 @@
 
 from django.conf.urls import url
 from .feeds.training_center import TrainingCenterFeed
-from .feeds.course import UpcomingCourseFeed, PastCourseFeed
+from .feeds.course import (
+    UpcomingCourseFeed,
+    PastCourseFeed,
+    UpcomingCourseProjectFeed,
+    PastCourseProjectFeed
+)
 from .views import (
     # Certifying Organisation.
     CertifyingOrganisationCreateView,
@@ -297,6 +302,12 @@ urlpatterns = [
         view=GetStatus.as_view(), name='get-status-list'),
 
     # Feeds
+    url(regex='^(?P<project_slug>[\w-]+)/feed/upcoming-course/$',
+        view=UpcomingCourseProjectFeed(),
+        name='feed-upcoming-project-course'),
+    url(regex='^(?P<project_slug>[\w-]+)/feed/past-course/$',
+        view=PastCourseProjectFeed(),
+        name='feed-past-project-course'),
     url(regex='^(?P<project_slug>[\w-]+)/certifyingorganisation/'
               '(?P<organisation_slug>[\w-]+)/feed/training-center/$',
         view=TrainingCenterFeed(),


### PR DESCRIPTION
fix #1158 

I added buttons for links to training geojson feed, upcoming courses feed and past courses feed:
![Screenshot from 2020-03-05 15-41-52](https://user-images.githubusercontent.com/26101337/75963523-3908cd80-5ef8-11ea-8928-e3f8bab2e4f2.png)

### example of geojson training center feed:
```json
{
   "rss": {
        "version": "2.0", 
         "channel": {
               "title": "GeoJSON Feed training center of Kartoza (Pty) Ltd", 
               "description": "These are the training center of Kartoza (Pty) Ltd.", 
               "link": "http://0.0.0.0:61202/en/qgis/certifyingorganisation/qgis-kartoza-pty-ltd/", 
               "homepage": "https://kartoza.com", 
               "lastBuildDate": "Thu, 05 Mar 2020 08:41:45 +0000", 
               "item": [
                    {
                        "type": "Feature", 
                         "geometry": {
                                 "type": "Point", 
                                 "coordinates": [32.65, -0.15]
                          }, 
                         "properties": {
                                   "name": "Uganda"
                           }
                  }, {
                       "type": "Feature", 
                       "geometry": {
                               "type": "Point", 
                               "coordinates": [11.6, 42.81]
                        }, 
                       "properties": {
                                "name": "Trieste ICTP"
                        }
                  }, {
                       "type": "Feature", 
                       "geometry": {
                              "type": "Point", 
                               "coordinates": [31.6, -26.67]
                        }, 
                       "properties": {
                                "name": "Swaziland"
                         }
                  }]
}}}
```

### Example of upcoming course feed:
```json
{
      "rss": {
          "version": "2.0", 
          "channel": {
               "title": "JSON Feed upcoming course of Kartoza (Pty) Ltd", 
               "description": "These are the upcoming course of Kartoza (Pty) Ltd.", 
               "link": "http://0.0.0.0:61202/en/qgis/certifyingorganisation/qgis-kartoza-pty-ltd/", 
               "lastBuildDate": "Thu, 05 Mar 2020 08:41:42 +0000", 
               "item": [
                   {
                         "title": "QGIS_Introduction to QGIS_2019-10-07-2019-10-09", 
                         "link": "http://0.0.0.0:61202/en/qgis/certifyingorganisation/qgis-kartoza-pty-ltd/course/qgis_introduction-qgis_2019-10-07-2019-10-09/", 
                         "start_date": "2020-04-01", 
                         "end_date": "2020-05-13", 
                         "course_convener": "Admire Nyakudya BSc (Hons) GIS and Remote Sensing", 
                         "course_type": "Introduction to QGIS", 
                         "language": "English", 
                         "trained_competence": "General introduction to QGIS", 
                         "training_center": {
                                 "type": "Feature", 
                                 "geometry": {
                                        "type": "Point", 
                                        "coordinates": [18.47, -34.11]
                                  }, 
                                "properties": {
                                        "name": "Cape Town"
                                 }}}
                  ]}}}
```

the past course feed will have the same item as the upcoming course feed but they are the courses that already finished